### PR TITLE
Update default training params for phi2 and llama2 7b

### DIFF
--- a/configs/llama-v2-7b/setup/project-settings.json
+++ b/configs/llama-v2-7b/setup/project-settings.json
@@ -199,7 +199,7 @@
         "label": "Max steps:",
         "info":"Training will be stopped when this number of steps is reached, regardless of the number of epochs.",
         "replaceToken": "<max_steps>",
-        "defaultValue": 1875
+        "defaultValue": 100
       },
       {
         "type": "String",

--- a/configs/phi-2/setup/project-settings.json
+++ b/configs/phi-2/setup/project-settings.json
@@ -115,14 +115,14 @@
         "label": "Lora r:",
         "info": "Lora attention dimension.",
         "replaceToken": "<lora_r>",
-        "defaultValue": 8
+        "defaultValue": 64
       },
       {
         "type": "Integer",
         "label": "Lora alpha:",
         "info": "The alpha parameter for Lora scaling",
         "replaceToken": "<lora_alpha>",
-        "defaultValue": 16
+        "defaultValue": 64
       },
       {
         "type": "Number",
@@ -199,7 +199,7 @@
         "label": "Max steps:",
         "info":"Training will be stopped when this number of steps is reached, regardless of the number of epochs.",
         "replaceToken": "<max_steps>",
-        "defaultValue": 1500
+        "defaultValue": 1200
       },
       {
         "type": "String",


### PR DESCRIPTION
Observed low training loss with updated phi2 params 
Reduce the training time to ~40min with updated Llama2 params while still achieving good model performance.