### PR TITLE
fix: update aca image

### DIFF
--- a/configs/Phi-3-mini-4k-instruct/infra/provision/finetuning.bicep
+++ b/configs/Phi-3-mini-4k-instruct/infra/provision/finetuning.bicep
@@ -137,7 +137,7 @@ resource acajob 'Microsoft.App/jobs@2023-11-02-preview' = {
     template: {
       containers: [
         {
-          image: 'docker.io/huggingface/transformers-all-latest-gpu'
+          image: 'mcr.microsoft.com/azureml/minimal-ubuntu20.04-py38-cuda11.6.2-gpu-inference'
           name: acaJobName
           command: [
             '/bin/bash'

--- a/configs/Phi-3-mini-4k-instruct/infra/provision/inference.bicep
+++ b/configs/Phi-3-mini-4k-instruct/infra/provision/inference.bicep
@@ -147,7 +147,7 @@ resource acaApp 'Microsoft.App/containerApps@2023-11-02-preview' = {
       terminationGracePeriodSeconds: null
       containers: [
         {
-          image: 'docker.io/huggingface/transformers-all-latest-gpu'
+          image: 'mcr.microsoft.com/azureml/minimal-ubuntu20.04-py38-cuda11.6.2-gpu-inference'
           name: acaAppName
           command: [
             '/bin/bash'

--- a/configs/mistral-7b/infra/provision/finetuning.bicep
+++ b/configs/mistral-7b/infra/provision/finetuning.bicep
@@ -137,7 +137,7 @@ resource acajob 'Microsoft.App/jobs@2023-11-02-preview' = {
     template: {
       containers: [
         {
-          image: 'docker.io/huggingface/transformers-all-latest-gpu'
+          image: 'mcr.microsoft.com/azureml/minimal-ubuntu20.04-py38-cuda11.6.2-gpu-inference'
           name: acaJobName
           command: [
             '/bin/bash'

--- a/configs/mistral-7b/infra/provision/inference.bicep
+++ b/configs/mistral-7b/infra/provision/inference.bicep
@@ -147,7 +147,7 @@ resource acaApp 'Microsoft.App/containerApps@2023-11-02-preview' = {
       terminationGracePeriodSeconds: null
       containers: [
         {
-          image: 'docker.io/huggingface/transformers-all-latest-gpu'
+          image: 'mcr.microsoft.com/azureml/minimal-ubuntu20.04-py38-cuda11.6.2-gpu-inference'
           name: acaAppName
           command: [
             '/bin/bash'

--- a/configs/phi-2/infra/provision/finetuning.bicep
+++ b/configs/phi-2/infra/provision/finetuning.bicep
@@ -137,7 +137,7 @@ resource acajob 'Microsoft.App/jobs@2023-11-02-preview' = {
     template: {
       containers: [
         {
-          image: 'docker.io/huggingface/transformers-all-latest-gpu'
+          image: 'mcr.microsoft.com/azureml/minimal-ubuntu20.04-py38-cuda11.6.2-gpu-inference'
           name: acaJobName
           command: [
             '/bin/bash'

--- a/configs/phi-2/infra/provision/inference.bicep
+++ b/configs/phi-2/infra/provision/inference.bicep
@@ -147,7 +147,7 @@ resource acaApp 'Microsoft.App/containerApps@2023-11-02-preview' = {
       terminationGracePeriodSeconds: null
       containers: [
         {
-          image: 'docker.io/huggingface/transformers-all-latest-gpu'
+          image: 'mcr.microsoft.com/azureml/minimal-ubuntu20.04-py38-cuda11.6.2-gpu-inference'
           name: acaAppName
           command: [
             '/bin/bash'


### PR DESCRIPTION
Use a smaller image for finetuning and inference.

```
> docker image ls
REPOSITORY                                                                    TAG       IMAGE ID       CREATED        SIZE
huggingface/transformers-all-latest-gpu                                       latest    86dd428a738b   6 hours ago    22.7GB
mcr.microsoft.com/azureml/minimal-ubuntu20.04-py38-cuda11.6.2-gpu-inference   latest    be6f6b0e6b51   3 months ago   9.16GB
```