### PR TITLE
fix: hf download and image

### DIFF
--- a/configs/Phi-3-mini-4k-instruct/infra/finetuning.config.json
+++ b/configs/Phi-3-mini-4k-instruct/infra/finetuning.config.json
@@ -7,7 +7,7 @@
   "COMMANDS": [
     "cd /mount",
     "pip install -r ./setup/requirements.txt",
-    "huggingface-cli download microsoft/Phi-3-mini-4k-instruct --revision main --local-dir ./model-cache/microsoft/Phi-3-mini-4k-instruct --local-dir-use-symlinks False",
+    "huggingface-cli download microsoft/Phi-3-mini-4k-instruct --revision main --local-dir ./model-cache/microsoft/Phi-3-mini-4k-instruct --local-dir-use-symlinks False --cache-dir ./cache/hfdownload",
     "python3 ./finetuning/invoke_olive.py"
   ]
 }

--- a/configs/Phi-3-mini-4k-instruct/infra/provision/finetuning.bicep
+++ b/configs/Phi-3-mini-4k-instruct/infra/provision/finetuning.bicep
@@ -138,7 +138,7 @@ resource acajob 'Microsoft.App/jobs@2023-11-02-preview' = {
     template: {
       containers: [
         {
-          image: 'mcr.microsoft.com/azureml/minimal-ubuntu20.04-py38-cuda11.6.2-gpu-inference'
+          image: 'docker.io/pytorch/pytorch:2.3.0-cuda11.8-cudnn8-runtime'
           name: acaJobName
           command: [
             '/bin/bash'

--- a/configs/Phi-3-mini-4k-instruct/infra/provision/finetuning.parameters.json
+++ b/configs/Phi-3-mini-4k-instruct/infra/provision/finetuning.parameters.json
@@ -9,7 +9,7 @@
       "value": [
         "cd /mount",
         "pip install -r ./setup/requirements.txt",
-        "huggingface-cli download microsoft/Phi-3-mini-4k-instruct --revision main --local-dir ./model-cache/microsoft/Phi-3-mini-4k-instruct --local-dir-use-symlinks False",
+        "huggingface-cli download microsoft/Phi-3-mini-4k-instruct --revision main --local-dir ./model-cache/microsoft/Phi-3-mini-4k-instruct --local-dir-use-symlinks False --cache-dir ./cache/hfdownload",
         "python3 ./finetuning/invoke_olive.py"
       ]
     },

--- a/configs/Phi-3-mini-4k-instruct/infra/provision/inference.bicep
+++ b/configs/Phi-3-mini-4k-instruct/infra/provision/inference.bicep
@@ -148,7 +148,7 @@ resource acaApp 'Microsoft.App/containerApps@2023-11-02-preview' = {
       terminationGracePeriodSeconds: null
       containers: [
         {
-          image: 'mcr.microsoft.com/azureml/minimal-ubuntu20.04-py38-cuda11.6.2-gpu-inference'
+          image: 'docker.io/pytorch/pytorch:2.3.0-cuda11.8-cudnn8-runtime'
           name: acaAppName
           command: [
             '/bin/bash'

--- a/configs/mistral-7b/infra/finetuning.config.json
+++ b/configs/mistral-7b/infra/finetuning.config.json
@@ -7,7 +7,7 @@
   "COMMANDS": [
     "cd /mount",
     "pip install -r ./setup/requirements.txt",
-    "huggingface-cli download mistralai/Mistral-7B-v0.1 --local-dir ./model-cache/mistralai/Mistral-7B --local-dir-use-symlinks False",
+    "huggingface-cli download mistralai/Mistral-7B-v0.1 --local-dir ./model-cache/mistralai/Mistral-7B --local-dir-use-symlinks False --cache-dir ./cache/hfdownload",
     "python3 ./finetuning/invoke_olive.py"
   ]
 }

--- a/configs/mistral-7b/infra/provision/finetuning.bicep
+++ b/configs/mistral-7b/infra/provision/finetuning.bicep
@@ -138,7 +138,7 @@ resource acajob 'Microsoft.App/jobs@2023-11-02-preview' = {
     template: {
       containers: [
         {
-          image: 'mcr.microsoft.com/azureml/minimal-ubuntu20.04-py38-cuda11.6.2-gpu-inference'
+          image: 'docker.io/pytorch/pytorch:2.3.0-cuda11.8-cudnn8-runtime'
           name: acaJobName
           command: [
             '/bin/bash'

--- a/configs/mistral-7b/infra/provision/finetuning.parameters.json
+++ b/configs/mistral-7b/infra/provision/finetuning.parameters.json
@@ -9,7 +9,7 @@
       "value": [
         "cd /mount",
         "pip install -r ./setup/requirements.txt",
-        "huggingface-cli download mistralai/Mistral-7B-v0.1 --local-dir ./model-cache/mistralai/Mistral-7B --local-dir-use-symlinks False",
+        "huggingface-cli download mistralai/Mistral-7B-v0.1 --local-dir ./model-cache/mistralai/Mistral-7B --local-dir-use-symlinks False --cache-dir ./cache/hfdownload",
         "python3 ./finetuning/invoke_olive.py"
       ]
     },

--- a/configs/mistral-7b/infra/provision/inference.bicep
+++ b/configs/mistral-7b/infra/provision/inference.bicep
@@ -148,7 +148,7 @@ resource acaApp 'Microsoft.App/containerApps@2023-11-02-preview' = {
       terminationGracePeriodSeconds: null
       containers: [
         {
-          image: 'mcr.microsoft.com/azureml/minimal-ubuntu20.04-py38-cuda11.6.2-gpu-inference'
+          image: 'docker.io/pytorch/pytorch:2.3.0-cuda11.8-cudnn8-runtime'
           name: acaAppName
           command: [
             '/bin/bash'

--- a/configs/phi-2/infra/finetuning.config.json
+++ b/configs/phi-2/infra/finetuning.config.json
@@ -7,7 +7,7 @@
   "COMMANDS": [
     "cd /mount",
     "pip install -r ./setup/requirements.txt",
-    "huggingface-cli download microsoft/phi-2 --revision d3186761bf5c4409f7679359284066c25ab668ee --local-dir ./model-cache/microsoft/phi-2 --local-dir-use-symlinks False",
+    "huggingface-cli download microsoft/phi-2 --revision d3186761bf5c4409f7679359284066c25ab668ee --local-dir ./model-cache/microsoft/phi-2 --local-dir-use-symlinks False --cache-dir ./cache/hfdownload",
     "python3 ./finetuning/invoke_olive.py"
   ]
 }

--- a/configs/phi-2/infra/provision/finetuning.bicep
+++ b/configs/phi-2/infra/provision/finetuning.bicep
@@ -138,7 +138,7 @@ resource acajob 'Microsoft.App/jobs@2023-11-02-preview' = {
     template: {
       containers: [
         {
-          image: 'mcr.microsoft.com/azureml/minimal-ubuntu20.04-py38-cuda11.6.2-gpu-inference'
+          image: 'docker.io/pytorch/pytorch:2.3.0-cuda11.8-cudnn8-runtime'
           name: acaJobName
           command: [
             '/bin/bash'

--- a/configs/phi-2/infra/provision/finetuning.parameters.json
+++ b/configs/phi-2/infra/provision/finetuning.parameters.json
@@ -9,7 +9,7 @@
       "value": [
         "cd /mount",
         "pip install -r ./setup/requirements.txt",
-        "huggingface-cli download microsoft/phi-2 --revision d3186761bf5c4409f7679359284066c25ab668ee --local-dir ./model-cache/microsoft/phi-2 --local-dir-use-symlinks False",
+        "huggingface-cli download microsoft/phi-2 --revision d3186761bf5c4409f7679359284066c25ab668ee --local-dir ./model-cache/microsoft/phi-2 --local-dir-use-symlinks False --cache-dir ./cache/hfdownload",
         "python3 ./finetuning/invoke_olive.py"
       ]
     },

--- a/configs/phi-2/infra/provision/inference.bicep
+++ b/configs/phi-2/infra/provision/inference.bicep
@@ -148,7 +148,7 @@ resource acaApp 'Microsoft.App/containerApps@2023-11-02-preview' = {
       terminationGracePeriodSeconds: null
       containers: [
         {
-          image: 'mcr.microsoft.com/azureml/minimal-ubuntu20.04-py38-cuda11.6.2-gpu-inference'
+          image: 'docker.io/pytorch/pytorch:2.3.0-cuda11.8-cudnn8-runtime'
           name: acaAppName
           command: [
             '/bin/bash'


### PR DESCRIPTION
`huggingface-cli download` may break on certain project due to package conflict, thus fixing by:
- Using a cu118 image to be consistent with requirements
- Adding `--cache-dir` option to download command to avoid cross-device file operations


---------------------------------
Error details:

```
Traceback (most recent call last):
File "/opt/miniconda/envs/amlenv/lib/python3.8/shutil.py", line 791, in move
os.rename(src, real_dst)
OSError: [Errno 18] Invalid cross-device link: '/home/dockeruser/.cache/huggingface/hub/tmpzke188tg' -> './model-cache/microsoft/phi-2/.gitattributes'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
File "/opt/miniconda/envs/amlenv/bin/huggingface-cli", line 8, in <module>
sys.exit(main())
File "/opt/miniconda/envs/amlenv/lib/python3.8/site-packages/huggingface_hub/commands/huggingface_cli.py", line 49, in main
service.run()
...
```

This is because old version of `huggingface-cli` was trying to move content cross devices (from cache to final dir)