### PR TITLE
fix: add default location in bicep parameters

### DIFF
--- a/configs/Phi-3-mini-4k-instruct/infra/provision/finetuning.bicep
+++ b/configs/Phi-3-mini-4k-instruct/infra/provision/finetuning.bicep
@@ -1,7 +1,7 @@
-param location string
 param defaultCommands array
 param maximumInstanceCount int
 param timeout int
+param location string = resourceGroup().location
 
 param resourceSuffix string = substring(uniqueString(resourceGroup().id), 0, 5)
 param storageAccountName string = 'waisstorage${resourceSuffix}'

--- a/configs/Phi-3-mini-4k-instruct/infra/provision/finetuning.parameters.json
+++ b/configs/Phi-3-mini-4k-instruct/infra/provision/finetuning.parameters.json
@@ -2,9 +2,6 @@
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "location": {
-      "value": "westus3"
-    },
     "defaultCommands": {
       "value": [
         "cd /mount",
@@ -18,6 +15,9 @@
     },
     "timeout": {
       "value": 10800
+    },
+    "location": {
+      "value": null
     },
     "storageAccountName": {
       "value": null

--- a/configs/Phi-3-mini-4k-instruct/infra/provision/inference.bicep
+++ b/configs/Phi-3-mini-4k-instruct/infra/provision/inference.bicep
@@ -1,6 +1,6 @@
-param location string
 param defaultCommands array
 param maximumInstanceCount int
+param location string = resourceGroup().location
 
 param resourceSuffix string = substring(uniqueString(resourceGroup().id), 0, 5)
 param storageAccountName string = 'waisstorage${resourceSuffix}'

--- a/configs/Phi-3-mini-4k-instruct/infra/provision/inference.parameters.json
+++ b/configs/Phi-3-mini-4k-instruct/infra/provision/inference.parameters.json
@@ -1,39 +1,39 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-      "defaultCommands": {
-        "value": [
-          "cd /mount",
-          "pip install -r ./setup/requirements.txt",
-          "cd /mount/inference",
-          "pip install -r ./requirements.txt",
-          "python3 ./gradio_chat.py"
-        ]
-      },
-      "maximumInstanceCount": {
-        "value": 2
-      },
-      "location": {
-        "value": null
-      },
-      "storageAccountName": {
-        "value": null
-      },
-      "fileShareName": {
-        "value": null
-      },
-      "acaEnvironmentName": {
-        "value": null
-      },
-      "acaEnvironmentStorageName": {
-        "value": null
-      },
-      "acaAppName": {
-        "value": null
-      },
-      "acaLogAnalyticsName": {
-        "value": null
-      }
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "defaultCommands": {
+      "value": [
+        "cd /mount",
+        "pip install -r ./setup/requirements.txt",
+        "cd /mount/inference",
+        "pip install -r ./requirements.txt",
+        "python3 ./gradio_chat.py"
+      ]
+    },
+    "maximumInstanceCount": {
+      "value": 2
+    },
+    "location": {
+      "value": null
+    },
+    "storageAccountName": {
+      "value": null
+    },
+    "fileShareName": {
+      "value": null
+    },
+    "acaEnvironmentName": {
+      "value": null
+    },
+    "acaEnvironmentStorageName": {
+      "value": null
+    },
+    "acaAppName": {
+      "value": null
+    },
+    "acaLogAnalyticsName": {
+      "value": null
     }
   }
+}

--- a/configs/Phi-3-mini-4k-instruct/infra/provision/inference.parameters.json
+++ b/configs/Phi-3-mini-4k-instruct/infra/provision/inference.parameters.json
@@ -2,9 +2,6 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-      "location": {
-        "value": "westus3"
-      },
       "defaultCommands": {
         "value": [
           "cd /mount",
@@ -16,6 +13,9 @@
       },
       "maximumInstanceCount": {
         "value": 2
+      },
+      "location": {
+        "value": null
       },
       "storageAccountName": {
         "value": null

--- a/configs/llama-v2-7b/infra/provision/finetuning.bicep
+++ b/configs/llama-v2-7b/infra/provision/finetuning.bicep
@@ -1,7 +1,7 @@
-param location string
 param defaultCommands array
 param maximumInstanceCount int
 param timeout int
+param location string = resourceGroup().location
 
 param resourceSuffix string = substring(uniqueString(resourceGroup().id), 0, 5)
 param storageAccountName string = 'waisstorage${resourceSuffix}'

--- a/configs/llama-v2-7b/infra/provision/finetuning.parameters.json
+++ b/configs/llama-v2-7b/infra/provision/finetuning.parameters.json
@@ -2,9 +2,6 @@
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "location": {
-      "value": "westus3"
-    },
     "defaultCommands": {
       "value": [
         "cd /mount",
@@ -18,6 +15,9 @@
     },
     "timeout": {
       "value": 10800
+    },
+    "location": {
+      "value": null
     },
     "storageAccountName": {
       "value": null

--- a/configs/llama-v2-7b/infra/provision/inference.bicep
+++ b/configs/llama-v2-7b/infra/provision/inference.bicep
@@ -1,6 +1,6 @@
-param location string
 param defaultCommands array
 param maximumInstanceCount int
+param location string = resourceGroup().location
 
 param resourceSuffix string = substring(uniqueString(resourceGroup().id), 0, 5)
 param storageAccountName string = 'waisstorage${resourceSuffix}'

--- a/configs/llama-v2-7b/infra/provision/inference.parameters.json
+++ b/configs/llama-v2-7b/infra/provision/inference.parameters.json
@@ -1,39 +1,39 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-      "defaultCommands": {
-        "value": [
-          "cd /mount",
-          "pip install -r ./setup/requirements.txt",
-          "cd /mount/inference",
-          "pip install -r ./requirements.txt",
-          "python3 ./gradio_chat.py"
-        ]
-      },
-      "maximumInstanceCount": {
-        "value": 2
-      },
-      "location": {
-        "value": null
-      },
-      "storageAccountName": {
-        "value": null
-      },
-      "fileShareName": {
-        "value": null
-      },
-      "acaEnvironmentName": {
-        "value": null
-      },
-      "acaEnvironmentStorageName": {
-        "value": null
-      },
-      "acaAppName": {
-        "value": null
-      },
-      "acaLogAnalyticsName": {
-        "value": null
-      }
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "defaultCommands": {
+      "value": [
+        "cd /mount",
+        "pip install -r ./setup/requirements.txt",
+        "cd /mount/inference",
+        "pip install -r ./requirements.txt",
+        "python3 ./gradio_chat.py"
+      ]
+    },
+    "maximumInstanceCount": {
+      "value": 2
+    },
+    "location": {
+      "value": null
+    },
+    "storageAccountName": {
+      "value": null
+    },
+    "fileShareName": {
+      "value": null
+    },
+    "acaEnvironmentName": {
+      "value": null
+    },
+    "acaEnvironmentStorageName": {
+      "value": null
+    },
+    "acaAppName": {
+      "value": null
+    },
+    "acaLogAnalyticsName": {
+      "value": null
     }
   }
+}

--- a/configs/llama-v2-7b/infra/provision/inference.parameters.json
+++ b/configs/llama-v2-7b/infra/provision/inference.parameters.json
@@ -2,9 +2,6 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-      "location": {
-        "value": "westus3"
-      },
       "defaultCommands": {
         "value": [
           "cd /mount",
@@ -16,6 +13,9 @@
       },
       "maximumInstanceCount": {
         "value": 2
+      },
+      "location": {
+        "value": null
       },
       "storageAccountName": {
         "value": null

--- a/configs/mistral-7b/infra/provision/finetuning.bicep
+++ b/configs/mistral-7b/infra/provision/finetuning.bicep
@@ -1,7 +1,7 @@
-param location string
 param defaultCommands array
 param maximumInstanceCount int
 param timeout int
+param location string = resourceGroup().location
 
 param resourceSuffix string = substring(uniqueString(resourceGroup().id), 0, 5)
 param storageAccountName string = 'waisstorage${resourceSuffix}'

--- a/configs/mistral-7b/infra/provision/finetuning.parameters.json
+++ b/configs/mistral-7b/infra/provision/finetuning.parameters.json
@@ -2,9 +2,6 @@
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "location": {
-      "value": "westus3"
-    },
     "defaultCommands": {
       "value": [
         "cd /mount",
@@ -15,6 +12,9 @@
     },
     "maximumInstanceCount": {
       "value": 2
+    },
+    "location": {
+      "value": null
     },
     "timeout": {
       "value": 10800

--- a/configs/mistral-7b/infra/provision/inference.bicep
+++ b/configs/mistral-7b/infra/provision/inference.bicep
@@ -1,6 +1,6 @@
-param location string
 param defaultCommands array
 param maximumInstanceCount int
+param location string = resourceGroup().location
 
 param resourceSuffix string = substring(uniqueString(resourceGroup().id), 0, 5)
 param storageAccountName string = 'waisstorage${resourceSuffix}'

--- a/configs/mistral-7b/infra/provision/inference.parameters.json
+++ b/configs/mistral-7b/infra/provision/inference.parameters.json
@@ -1,39 +1,39 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-      "defaultCommands": {
-        "value": [
-          "cd /mount",
-          "pip install -r ./setup/requirements.txt",
-          "cd /mount/inference",
-          "pip install -r ./requirements.txt",
-          "python3 ./gradio_chat.py"
-        ]
-      },
-      "maximumInstanceCount": {
-        "value": 2
-      },
-      "location": {
-        "value": null
-      },
-      "storageAccountName": {
-        "value": null
-      },
-      "fileShareName": {
-        "value": null
-      },
-      "acaEnvironmentName": {
-        "value": null
-      },
-      "acaEnvironmentStorageName": {
-        "value": null
-      },
-      "acaAppName": {
-        "value": null
-      },
-      "acaLogAnalyticsName": {
-        "value": null
-      }
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "defaultCommands": {
+      "value": [
+        "cd /mount",
+        "pip install -r ./setup/requirements.txt",
+        "cd /mount/inference",
+        "pip install -r ./requirements.txt",
+        "python3 ./gradio_chat.py"
+      ]
+    },
+    "maximumInstanceCount": {
+      "value": 2
+    },
+    "location": {
+      "value": null
+    },
+    "storageAccountName": {
+      "value": null
+    },
+    "fileShareName": {
+      "value": null
+    },
+    "acaEnvironmentName": {
+      "value": null
+    },
+    "acaEnvironmentStorageName": {
+      "value": null
+    },
+    "acaAppName": {
+      "value": null
+    },
+    "acaLogAnalyticsName": {
+      "value": null
     }
   }
+}

--- a/configs/mistral-7b/infra/provision/inference.parameters.json
+++ b/configs/mistral-7b/infra/provision/inference.parameters.json
@@ -2,9 +2,6 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-      "location": {
-        "value": "westus3"
-      },
       "defaultCommands": {
         "value": [
           "cd /mount",
@@ -16,6 +13,9 @@
       },
       "maximumInstanceCount": {
         "value": 2
+      },
+      "location": {
+        "value": null
       },
       "storageAccountName": {
         "value": null

--- a/configs/phi-1_5/infra/provision/finetuning.bicep
+++ b/configs/phi-1_5/infra/provision/finetuning.bicep
@@ -1,7 +1,7 @@
-param location string
 param defaultCommands array
 param maximumInstanceCount int
 param timeout int
+param location string = resourceGroup().location
 
 param resourceSuffix string = substring(uniqueString(resourceGroup().id), 0, 5)
 param storageAccountName string = 'waisstorage${resourceSuffix}'

--- a/configs/phi-1_5/infra/provision/finetuning.parameters.json
+++ b/configs/phi-1_5/infra/provision/finetuning.parameters.json
@@ -2,9 +2,6 @@
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "location": {
-      "value": "westus3"
-    },
     "defaultCommands": {
       "value": [
         "cd /mount",
@@ -18,6 +15,9 @@
     },
     "timeout": {
       "value": 10800
+    },
+    "location": {
+      "value": null
     },
     "storageAccountName": {
       "value": null

--- a/configs/phi-1_5/infra/provision/inference.bicep
+++ b/configs/phi-1_5/infra/provision/inference.bicep
@@ -1,6 +1,6 @@
-param location string
 param defaultCommands array
 param maximumInstanceCount int
+param location string = resourceGroup().location
 
 param resourceSuffix string = substring(uniqueString(resourceGroup().id), 0, 5)
 param storageAccountName string = 'waisstorage${resourceSuffix}'

--- a/configs/phi-1_5/infra/provision/inference.parameters.json
+++ b/configs/phi-1_5/infra/provision/inference.parameters.json
@@ -1,39 +1,39 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-      "location": {
-        "value": "westus3"
-      },
-      "defaultCommands": {
-        "value": [
-          "cd /mount",
-          "pip install -r ./setup/requirements.txt",
-          "cd /mount/inference",
-          "pip install -r ./requirements.txt",
-          "python3 ./gradio_chat.py"
-        ]
-      },
-      "maximumInstanceCount": {
-        "value": 2
-      },
-      "storageAccountName": {
-        "value": null
-      },
-      "fileShareName": {
-        "value": null
-      },
-      "acaEnvironmentName": {
-        "value": null
-      },
-      "acaEnvironmentStorageName": {
-        "value": null
-      },
-      "acaAppName": {
-        "value": null
-      },
-      "acaLogAnalyticsName": {
-        "value": null
-      }
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "defaultCommands": {
+      "value": [
+        "cd /mount",
+        "pip install -r ./setup/requirements.txt",
+        "cd /mount/inference",
+        "pip install -r ./requirements.txt",
+        "python3 ./gradio_chat.py"
+      ]
+    },
+    "maximumInstanceCount": {
+      "value": 2
+    },
+    "location": {
+      "value": null
+    },
+    "storageAccountName": {
+      "value": null
+    },
+    "fileShareName": {
+      "value": null
+    },
+    "acaEnvironmentName": {
+      "value": null
+    },
+    "acaEnvironmentStorageName": {
+      "value": null
+    },
+    "acaAppName": {
+      "value": null
+    },
+    "acaLogAnalyticsName": {
+      "value": null
     }
   }
+}

--- a/configs/phi-2/infra/provision/finetuning.bicep
+++ b/configs/phi-2/infra/provision/finetuning.bicep
@@ -1,7 +1,7 @@
-param location string
 param defaultCommands array
 param maximumInstanceCount int
 param timeout int
+param location string = resourceGroup().location
 
 param resourceSuffix string = substring(uniqueString(resourceGroup().id), 0, 5)
 param storageAccountName string = 'waisstorage${resourceSuffix}'

--- a/configs/phi-2/infra/provision/finetuning.parameters.json
+++ b/configs/phi-2/infra/provision/finetuning.parameters.json
@@ -2,9 +2,6 @@
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "location": {
-      "value": "westus3"
-    },
     "defaultCommands": {
       "value": [
         "cd /mount",
@@ -18,6 +15,9 @@
     },
     "timeout": {
       "value": 10800
+    },
+    "location": {
+      "value": null
     },
     "storageAccountName": {
       "value": null

--- a/configs/phi-2/infra/provision/inference.bicep
+++ b/configs/phi-2/infra/provision/inference.bicep
@@ -1,6 +1,6 @@
-param location string
 param defaultCommands array
 param maximumInstanceCount int
+param location string = resourceGroup().location
 
 param resourceSuffix string = substring(uniqueString(resourceGroup().id), 0, 5)
 param storageAccountName string = 'waisstorage${resourceSuffix}'

--- a/configs/phi-2/infra/provision/inference.parameters.json
+++ b/configs/phi-2/infra/provision/inference.parameters.json
@@ -1,39 +1,39 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-      "location": {
-        "value": "westus3"
-      },
-      "defaultCommands": {
-        "value": [
-          "cd /mount",
-          "pip install -r ./setup/requirements.txt",
-          "cd /mount/inference",
-          "pip install -r ./requirements.txt",
-          "python3 ./gradio_chat.py"
-        ]
-      },
-      "maximumInstanceCount": {
-        "value": 2
-      },
-      "storageAccountName": {
-        "value": null
-      },
-      "fileShareName": {
-        "value": null
-      },
-      "acaEnvironmentName": {
-        "value": null
-      },
-      "acaEnvironmentStorageName": {
-        "value": null
-      },
-      "acaAppName": {
-        "value": null
-      },
-      "acaLogAnalyticsName": {
-        "value": null
-      }
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "defaultCommands": {
+      "value": [
+        "cd /mount",
+        "pip install -r ./setup/requirements.txt",
+        "cd /mount/inference",
+        "pip install -r ./requirements.txt",
+        "python3 ./gradio_chat.py"
+      ]
+    },
+    "maximumInstanceCount": {
+      "value": 2
+    },
+    "location": {
+      "value": null
+    },
+    "storageAccountName": {
+      "value": null
+    },
+    "fileShareName": {
+      "value": null
+    },
+    "acaEnvironmentName": {
+      "value": null
+    },
+    "acaEnvironmentStorageName": {
+      "value": null
+    },
+    "acaAppName": {
+      "value": null
+    },
+    "acaLogAnalyticsName": {
+      "value": null
     }
   }
+}

--- a/configs/zephyr-7b-beta/infra/provision/finetuning.bicep
+++ b/configs/zephyr-7b-beta/infra/provision/finetuning.bicep
@@ -1,7 +1,7 @@
-param location string
 param defaultCommands array
 param maximumInstanceCount int
 param timeout int
+param location string = resourceGroup().location
 
 param resourceSuffix string = substring(uniqueString(resourceGroup().id), 0, 5)
 param storageAccountName string = 'waisstorage${resourceSuffix}'

--- a/configs/zephyr-7b-beta/infra/provision/finetuning.parameters.json
+++ b/configs/zephyr-7b-beta/infra/provision/finetuning.parameters.json
@@ -2,9 +2,6 @@
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "location": {
-      "value": "westus3"
-    },
     "defaultCommands": {
       "value": [
         "cd /mount",
@@ -18,6 +15,9 @@
     },
     "timeout": {
       "value": 10800
+    },
+    "location": {
+      "value": null
     },
     "storageAccountName": {
       "value": null

--- a/configs/zephyr-7b-beta/infra/provision/inference.bicep
+++ b/configs/zephyr-7b-beta/infra/provision/inference.bicep
@@ -1,6 +1,6 @@
-param location string
 param defaultCommands array
 param maximumInstanceCount int
+param location string = resourceGroup().location
 
 param resourceSuffix string = substring(uniqueString(resourceGroup().id), 0, 5)
 param storageAccountName string = 'waisstorage${resourceSuffix}'

--- a/configs/zephyr-7b-beta/infra/provision/inference.parameters.json
+++ b/configs/zephyr-7b-beta/infra/provision/inference.parameters.json
@@ -2,9 +2,6 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-      "location": {
-        "value": "westus3"
-      },
       "defaultCommands": {
         "value": [
           "cd /mount",
@@ -16,6 +13,9 @@
       },
       "maximumInstanceCount": {
         "value": 2
+      },
+      "location": {
+        "value": null
       },
       "storageAccountName": {
         "value": null


### PR DESCRIPTION
Previously, users had to set the location in two places: while creating the resource group and in the bicep parameter. 
After this change, users only need to set the location once by default.

Current steps:
![image](https://github.com/microsoft/windows-ai-studio-templates/assets/49138419/35435302-3060-4778-a0f0-49d962de5f61)
![image](https://github.com/microsoft/windows-ai-studio-templates/assets/49138419/c605343c-c8c0-4a90-9748-25ae1a8f6d81)
![image](https://github.com/microsoft/windows-ai-studio-templates/assets/49138419/360dc66c-73af-456a-888d-8e803d8de9af)
![image](https://github.com/microsoft/windows-ai-studio-templates/assets/49138419/61a99834-13d1-492e-94b8-13c94d1d8f6e)
