### PR TITLE
fix: for remote finetuning, add step to check finetune output

### DIFF
--- a/configs/Phi-3-mini-4k-instruct/infra/finetuning.config.json
+++ b/configs/Phi-3-mini-4k-instruct/infra/finetuning.config.json
@@ -8,6 +8,6 @@
     "cd /mount",
     "pip install -r ./setup/requirements.txt",
     "huggingface-cli download microsoft/Phi-3-mini-4k-instruct --revision main --local-dir ./model-cache/microsoft/Phi-3-mini-4k-instruct --local-dir-use-symlinks False --cache-dir ./cache/hfdownload",
-    "python3 ./finetuning/invoke_olive.py"
+    "python3 ./finetuning/invoke_olive.py && find models/ -print | grep adapter/adapter"
   ]
 }

--- a/configs/Phi-3-mini-4k-instruct/infra/provision/finetuning.parameters.json
+++ b/configs/Phi-3-mini-4k-instruct/infra/provision/finetuning.parameters.json
@@ -7,7 +7,7 @@
         "cd /mount",
         "pip install -r ./setup/requirements.txt",
         "huggingface-cli download microsoft/Phi-3-mini-4k-instruct --revision main --local-dir ./model-cache/microsoft/Phi-3-mini-4k-instruct --local-dir-use-symlinks False --cache-dir ./cache/hfdownload",
-        "python3 ./finetuning/invoke_olive.py"
+        "python3 ./finetuning/invoke_olive.py && find models/ -print | grep adapter/adapter"
       ]
     },
     "maximumInstanceCount": {

--- a/configs/llama-v2-7b/infra/finetuning.config.json
+++ b/configs/llama-v2-7b/infra/finetuning.config.json
@@ -8,6 +8,6 @@
     "cd /mount",
     "pip install -r ./setup/requirements.txt",
     "huggingface-cli download meta-llama/Llama-2-7b-hf --revision main --local-dir ./model-cache/meta-llama/Llama-2-7b --local-dir-use-symlinks False --cache-dir ./cache/hfdownload",
-    "python3 ./finetuning/invoke_olive.py"
+    "python3 ./finetuning/invoke_olive.py && find models/ -print | grep adapter/adapter"
   ]
 }

--- a/configs/llama-v2-7b/infra/provision/finetuning.parameters.json
+++ b/configs/llama-v2-7b/infra/provision/finetuning.parameters.json
@@ -7,7 +7,7 @@
         "cd /mount",
         "pip install -r ./setup/requirements.txt",
         "huggingface-cli download meta-llama/Llama-2-7b-hf --revision main --local-dir ./model-cache/meta-llama/Llama-2-7b --local-dir-use-symlinks False --cache-dir ./cache/hfdownload",
-        "python3 ./finetuning/invoke_olive.py"
+        "python3 ./finetuning/invoke_olive.py && find models/ -print | grep adapter/adapter"
       ]
     },
     "maximumInstanceCount": {

--- a/configs/mistral-7b/infra/finetuning.config.json
+++ b/configs/mistral-7b/infra/finetuning.config.json
@@ -8,6 +8,6 @@
     "cd /mount",
     "pip install -r ./setup/requirements.txt",
     "huggingface-cli download mistralai/Mistral-7B-v0.1 --local-dir ./model-cache/mistralai/Mistral-7B --local-dir-use-symlinks False --cache-dir ./cache/hfdownload",
-    "python3 ./finetuning/invoke_olive.py"
+    "python3 ./finetuning/invoke_olive.py && find models/ -print | grep adapter/adapter"
   ]
 }

--- a/configs/mistral-7b/infra/provision/finetuning.parameters.json
+++ b/configs/mistral-7b/infra/provision/finetuning.parameters.json
@@ -7,7 +7,7 @@
         "cd /mount",
         "pip install -r ./setup/requirements.txt",
         "huggingface-cli download mistralai/Mistral-7B-v0.1 --local-dir ./model-cache/mistralai/Mistral-7B --local-dir-use-symlinks False --cache-dir ./cache/hfdownload",
-        "python3 ./finetuning/invoke_olive.py"
+        "python3 ./finetuning/invoke_olive.py && find models/ -print | grep adapter/adapter"
       ]
     },
     "maximumInstanceCount": {

--- a/configs/phi-1_5/infra/finetuning.config.json
+++ b/configs/phi-1_5/infra/finetuning.config.json
@@ -8,6 +8,6 @@
     "cd /mount",
     "pip install -r ./setup/requirements.txt",
     "huggingface-cli download microsoft/phi-1_5 --revision d38e6f954ec29b96fe2cf033937dad64e279b5d9 --local-dir ./model-cache/microsoft/phi-1_5 --local-dir-use-symlinks False --cache-dir ./cache/hfdownload",
-    "python3 ./finetuning/invoke_olive.py"
+    "python3 ./finetuning/invoke_olive.py && find models/ -print | grep adapter/adapter"
   ]
 }

--- a/configs/phi-1_5/infra/provision/finetuning.parameters.json
+++ b/configs/phi-1_5/infra/provision/finetuning.parameters.json
@@ -7,7 +7,7 @@
         "cd /mount",
         "pip install -r ./setup/requirements.txt",
         "huggingface-cli download microsoft/phi-1_5 --revision d38e6f954ec29b96fe2cf033937dad64e279b5d9 --local-dir ./model-cache/microsoft/phi-1_5 --local-dir-use-symlinks False --cache-dir ./cache/hfdownload",
-        "python3 ./finetuning/invoke_olive.py"
+        "python3 ./finetuning/invoke_olive.py && find models/ -print | grep adapter/adapter"
       ]
     },
     "maximumInstanceCount": {

--- a/configs/phi-2/infra/finetuning.config.json
+++ b/configs/phi-2/infra/finetuning.config.json
@@ -8,6 +8,6 @@
     "cd /mount",
     "pip install -r ./setup/requirements.txt",
     "huggingface-cli download microsoft/phi-2 --revision d3186761bf5c4409f7679359284066c25ab668ee --local-dir ./model-cache/microsoft/phi-2 --local-dir-use-symlinks False --cache-dir ./cache/hfdownload",
-    "python3 ./finetuning/invoke_olive.py"
+    "python3 ./finetuning/invoke_olive.py && find models/ -print | grep adapter/adapter"
   ]
 }

--- a/configs/phi-2/infra/provision/finetuning.parameters.json
+++ b/configs/phi-2/infra/provision/finetuning.parameters.json
@@ -7,7 +7,7 @@
         "cd /mount",
         "pip install -r ./setup/requirements.txt",
         "huggingface-cli download microsoft/phi-2 --revision d3186761bf5c4409f7679359284066c25ab668ee --local-dir ./model-cache/microsoft/phi-2 --local-dir-use-symlinks False --cache-dir ./cache/hfdownload",
-        "python3 ./finetuning/invoke_olive.py"
+        "python3 ./finetuning/invoke_olive.py && find models/ -print | grep adapter/adapter"
       ]
     },
     "maximumInstanceCount": {

--- a/configs/zephyr-7b-beta/infra/finetuning.config.json
+++ b/configs/zephyr-7b-beta/infra/finetuning.config.json
@@ -8,6 +8,6 @@
     "cd /mount",
     "pip install -r ./setup/requirements.txt",
     "huggingface-cli download HuggingFaceH4/zephyr-7b-beta --revision main --local-dir ./model-cache/HuggingFaceH4/zephyr-7b-beta --local-dir-use-symlinks False --cache-dir ./cache/hfdownload",
-    "python3 ./finetuning/invoke_olive.py"
+    "python3 ./finetuning/invoke_olive.py && find models/ -print | grep adapter/adapter"
   ]
 }

--- a/configs/zephyr-7b-beta/infra/provision/finetuning.parameters.json
+++ b/configs/zephyr-7b-beta/infra/provision/finetuning.parameters.json
@@ -7,7 +7,7 @@
         "cd /mount",
         "pip install -r ./setup/requirements.txt",
         "huggingface-cli download HuggingFaceH4/zephyr-7b-beta --revision main --local-dir ./model-cache/HuggingFaceH4/zephyr-7b-beta --local-dir-use-symlinks False --cache-dir ./cache/hfdownload",
-        "python3 ./finetuning/invoke_olive.py"
+        "python3 ./finetuning/invoke_olive.py && find models/ -print | grep adapter/adapter"
       ]
     },
     "maximumInstanceCount": {


### PR DESCRIPTION
Adjust finetune script to `python3 ./finetuning/invoke_olive.py && find models/ -print | grep adapter/adapter`, so, either python error or adapter not generated will mark the job as failed.