### PR TITLE
fix: update remote config according to the latest deps version

### DIFF
--- a/configs/Phi-3-mini-4k-instruct/infra/provision/finetuning.parameters.json
+++ b/configs/Phi-3-mini-4k-instruct/infra/provision/finetuning.parameters.json
@@ -5,8 +5,9 @@
     "defaultCommands": {
       "value": [
         "cd /mount",
-        "pip install -r ./setup/requirements.txt",
+        "pip install huggingface-hub==0.22.2",
         "huggingface-cli download microsoft/Phi-3-mini-4k-instruct --revision main --local-dir ./model-cache/microsoft/Phi-3-mini-4k-instruct --local-dir-use-symlinks False --cache-dir ./cache/hfdownload",
+        "pip install -r ./setup/requirements.txt",
         "python3 ./finetuning/invoke_olive.py && find models/ -print | grep adapter/adapter"
       ]
     },

--- a/configs/Phi-3-mini-4k-instruct/infra/provision/inference.bicep
+++ b/configs/Phi-3-mini-4k-instruct/infra/provision/inference.bicep
@@ -192,8 +192,8 @@ resource acaApp 'Microsoft.App/containerApps@2023-11-02-preview' = {
                 scheme: 'HTTP'
               }
               initialDelaySeconds: 60
-              periodSeconds: 10
-              failureThreshold: 60
+              periodSeconds: 240
+              failureThreshold: 10
             }
           ]
           volumeMounts: [

--- a/configs/Phi-3-mini-4k-instruct/infra/provision/inference.parameters.json
+++ b/configs/Phi-3-mini-4k-instruct/infra/provision/inference.parameters.json
@@ -5,9 +5,10 @@
     "defaultCommands": {
       "value": [
         "cd /mount",
-        "pip install -r ./setup/requirements.txt",
+        "mkdir .cache",
+        "pip install -r ./setup/requirements.txt torch==2.3.0 torchvision==0.18.0 torchaudio==2.3.0 --cache-dir /mount/.cache",
         "cd /mount/inference",
-        "pip install -r ./requirements.txt",
+        "pip install -r ./requirements.txt --cache-dir /mount/.cache",
         "python3 ./gradio_chat.py"
       ]
     },

--- a/configs/Phi-3-mini-4k-instruct/infra/provision/inference.parameters.json
+++ b/configs/Phi-3-mini-4k-instruct/infra/provision/inference.parameters.json
@@ -5,7 +5,7 @@
     "defaultCommands": {
       "value": [
         "cd /mount",
-        "mkdir .cache",
+        "mkdir -p .cache",
         "pip install -r ./setup/requirements.txt torch==2.3.0 torchvision==0.18.0 torchaudio==2.3.0 --cache-dir /mount/.cache",
         "cd /mount/inference",
         "pip install -r ./requirements.txt --cache-dir /mount/.cache",

--- a/configs/llama-v2-7b/README.md
+++ b/configs/llama-v2-7b/README.md
@@ -95,7 +95,7 @@ Monitor the progress of the provision through the link displayed in the output c
 ### Add Huggingface Token to the Azure Container App Secret
 If you're using Llama, ensure to accept the LICENSE of [llama](https://huggingface.co/meta-llama/Llama-2-7b-hf) on HuggingFace. 
 Following this, set your HuggingFace token as an environment variable to avoid the need for manual login on the Hugging Face Hub.
-You can do this using the `AI Toolkit: Add Azure Container Apps Job secret for fine-tuning command`. With this command, you can set the secret name as [`HUGGING_FACE_HUB_TOKEN`](https://huggingface.co/docs/huggingface_hub/package_reference/environment_variables#hftoken) and use your Hugging Face token as the secret value.
+You can do this using the `AI Toolkit: Add Azure Container Apps Job secret for fine-tuning command`. With this command, you can set the secret name as [`HF_TOKEN`](https://huggingface.co/docs/huggingface_hub/package_reference/environment_variables#hftoken) and use your Hugging Face token as the secret value.
 
 ### Run Fine-tuning
 To start the remote fine-tuning job, execute the `AI Toolkit: Run fine-tuning` command.

--- a/configs/llama-v2-7b/infra/provision/finetuning.parameters.json
+++ b/configs/llama-v2-7b/infra/provision/finetuning.parameters.json
@@ -5,8 +5,9 @@
     "defaultCommands": {
       "value": [
         "cd /mount",
-        "pip install -r ./setup/requirements.txt",
+        "pip install huggingface-hub==0.22.2",
         "huggingface-cli download meta-llama/Llama-2-7b-hf --revision main --local-dir ./model-cache/meta-llama/Llama-2-7b --local-dir-use-symlinks False --cache-dir ./cache/hfdownload",
+        "pip install -r ./setup/requirements.txt",
         "python3 ./finetuning/invoke_olive.py && find models/ -print | grep adapter/adapter"
       ]
     },

--- a/configs/llama-v2-7b/infra/provision/inference.bicep
+++ b/configs/llama-v2-7b/infra/provision/inference.bicep
@@ -192,8 +192,8 @@ resource acaApp 'Microsoft.App/containerApps@2023-11-02-preview' = {
                 scheme: 'HTTP'
               }
               initialDelaySeconds: 60
-              periodSeconds: 10
-              failureThreshold: 60
+              periodSeconds: 240
+              failureThreshold: 10
             }
           ]
           volumeMounts: [

--- a/configs/llama-v2-7b/infra/provision/inference.parameters.json
+++ b/configs/llama-v2-7b/infra/provision/inference.parameters.json
@@ -5,9 +5,10 @@
     "defaultCommands": {
       "value": [
         "cd /mount",
-        "pip install -r ./setup/requirements.txt",
+        "mkdir .cache",
+        "pip install -r ./setup/requirements.txt torch==2.3.0 torchvision==0.18.0 torchaudio==2.3.0 --cache-dir /mount/.cache",
         "cd /mount/inference",
-        "pip install -r ./requirements.txt",
+        "pip install -r ./requirements.txt --cache-dir /mount/.cache",
         "python3 ./gradio_chat.py"
       ]
     },

--- a/configs/llama-v2-7b/infra/provision/inference.parameters.json
+++ b/configs/llama-v2-7b/infra/provision/inference.parameters.json
@@ -5,7 +5,7 @@
     "defaultCommands": {
       "value": [
         "cd /mount",
-        "mkdir .cache",
+        "mkdir -p .cache",
         "pip install -r ./setup/requirements.txt torch==2.3.0 torchvision==0.18.0 torchaudio==2.3.0 --cache-dir /mount/.cache",
         "cd /mount/inference",
         "pip install -r ./requirements.txt --cache-dir /mount/.cache",

--- a/configs/llama-v3-8b/README.md
+++ b/configs/llama-v3-8b/README.md
@@ -76,7 +76,7 @@ Monitor the progress of the provision through the link displayed in the output c
 ### Add Huggingface Token to the Azure Container App Secret
 If you're using Llama, ensure to accept the LICENSE of [llama](https://huggingface.co/meta-llama/Meta-Llama-3-8B) on HuggingFace. 
 Following this, set your HuggingFace token as an environment variable to avoid the need for manual login on the Hugging Face Hub.
-You can do this using the `AI Toolkit: Add Azure Container Apps Job secret for fine-tuning command`. With this command, you can set the secret name as [`HUGGING_FACE_HUB_TOKEN`](https://huggingface.co/docs/huggingface_hub/package_reference/environment_variables#hftoken) and use your Hugging Face token as the secret value.
+You can do this using the `AI Toolkit: Add Azure Container Apps Job secret for fine-tuning command`. With this command, you can set the secret name as [`HF_TOKEN`](https://huggingface.co/docs/huggingface_hub/package_reference/environment_variables#hftoken) and use your Hugging Face token as the secret value.
 
 ### Run Fine-tuning
 To start the remote fine-tuning job, execute the `AI Toolkit: Run fine-tuning` command.

--- a/configs/llama-v3-8b/infra/provision/finetuning.parameters.json
+++ b/configs/llama-v3-8b/infra/provision/finetuning.parameters.json
@@ -5,8 +5,9 @@
     "defaultCommands": {
       "value": [
         "cd /mount",
-        "pip install -r ./setup/requirements.txt",
+        "pip install huggingface-hub==0.22.2",
         "huggingface-cli download meta-llama/Meta-Llama-3-8B --revision main --local-dir ./model-cache/meta-llama/Llama-v3-8b --local-dir-use-symlinks False --cache-dir ./cache/hfdownload",
+        "pip install -r ./setup/requirements.txt",
         "python3 ./finetuning/invoke_olive.py && find models/ -print | grep adapter/adapter"
       ]
     },

--- a/configs/llama-v3-8b/infra/provision/inference.bicep
+++ b/configs/llama-v3-8b/infra/provision/inference.bicep
@@ -192,8 +192,8 @@ resource acaApp 'Microsoft.App/containerApps@2023-11-02-preview' = {
                 scheme: 'HTTP'
               }
               initialDelaySeconds: 60
-              periodSeconds: 10
-              failureThreshold: 60
+              periodSeconds: 240
+              failureThreshold: 10
             }
           ]
           volumeMounts: [

--- a/configs/llama-v3-8b/infra/provision/inference.parameters.json
+++ b/configs/llama-v3-8b/infra/provision/inference.parameters.json
@@ -5,9 +5,10 @@
     "defaultCommands": {
       "value": [
         "cd /mount",
-        "pip install -r ./setup/requirements.txt",
+        "mkdir .cache",
+        "pip install -r ./setup/requirements.txt torch==2.3.0 torchvision==0.18.0 torchaudio==2.3.0 --cache-dir /mount/.cache",
         "cd /mount/inference",
-        "pip install -r ./requirements.txt",
+        "pip install -r ./requirements.txt --cache-dir /mount/.cache",
         "python3 ./gradio_chat.py"
       ]
     },

--- a/configs/llama-v3-8b/infra/provision/inference.parameters.json
+++ b/configs/llama-v3-8b/infra/provision/inference.parameters.json
@@ -5,7 +5,7 @@
     "defaultCommands": {
       "value": [
         "cd /mount",
-        "mkdir .cache",
+        "mkdir -p .cache",
         "pip install -r ./setup/requirements.txt torch==2.3.0 torchvision==0.18.0 torchaudio==2.3.0 --cache-dir /mount/.cache",
         "cd /mount/inference",
         "pip install -r ./requirements.txt --cache-dir /mount/.cache",

--- a/configs/mistral-7b/README.md
+++ b/configs/mistral-7b/README.md
@@ -104,7 +104,7 @@ Monitor the progress of the provision through the link displayed in the output c
 ### Add Huggingface Token to the Azure Container App Secret
 If you're using Mistral, ensure to accept the LICENSE of [Mistral](https://huggingface.co/mistralai/Mistral-7B-v0.1) on HuggingFace. 
 Following this, set your HuggingFace token as an environment variable to avoid the need for manual login on the Hugging Face Hub.
-You can do this using the `AI Toolkit: Add Azure Container Apps Job secret for fine-tuning command`. With this command, you can set the secret name as [`HUGGING_FACE_HUB_TOKEN`](https://huggingface.co/docs/huggingface_hub/package_reference/environment_variables#hftoken) and use your Hugging Face token as the secret value.
+You can do this using the `AI Toolkit: Add Azure Container Apps Job secret for fine-tuning command`. With this command, you can set the secret name as [`HF_TOKEN`](https://huggingface.co/docs/huggingface_hub/package_reference/environment_variables#hftoken) and use your Hugging Face token as the secret value.
 
 ### Run Fine-tuning
 To start the remote fine-tuning job, execute the `AI Toolkit: Run fine-tuning` command.

--- a/configs/mistral-7b/infra/provision/finetuning.parameters.json
+++ b/configs/mistral-7b/infra/provision/finetuning.parameters.json
@@ -5,8 +5,9 @@
     "defaultCommands": {
       "value": [
         "cd /mount",
-        "pip install -r ./setup/requirements.txt",
+        "pip install huggingface-hub==0.22.2",
         "huggingface-cli download mistralai/Mistral-7B-v0.1 --local-dir ./model-cache/mistralai/Mistral-7B --local-dir-use-symlinks False --cache-dir ./cache/hfdownload",
+        "pip install -r ./setup/requirements.txt",
         "python3 ./finetuning/invoke_olive.py && find models/ -print | grep adapter/adapter"
       ]
     },

--- a/configs/mistral-7b/infra/provision/inference.bicep
+++ b/configs/mistral-7b/infra/provision/inference.bicep
@@ -192,8 +192,8 @@ resource acaApp 'Microsoft.App/containerApps@2023-11-02-preview' = {
                 scheme: 'HTTP'
               }
               initialDelaySeconds: 60
-              periodSeconds: 10
-              failureThreshold: 60
+              periodSeconds: 240
+              failureThreshold: 10
             }
           ]
           volumeMounts: [

--- a/configs/mistral-7b/infra/provision/inference.parameters.json
+++ b/configs/mistral-7b/infra/provision/inference.parameters.json
@@ -5,9 +5,10 @@
     "defaultCommands": {
       "value": [
         "cd /mount",
-        "pip install -r ./setup/requirements.txt",
+        "mkdir .cache",
+        "pip install -r ./setup/requirements.txt torch==2.3.0 torchvision==0.18.0 torchaudio==2.3.0 --cache-dir /mount/.cache",
         "cd /mount/inference",
-        "pip install -r ./requirements.txt",
+        "pip install -r ./requirements.txt --cache-dir /mount/.cache",
         "python3 ./gradio_chat.py"
       ]
     },

--- a/configs/mistral-7b/infra/provision/inference.parameters.json
+++ b/configs/mistral-7b/infra/provision/inference.parameters.json
@@ -5,7 +5,7 @@
     "defaultCommands": {
       "value": [
         "cd /mount",
-        "mkdir .cache",
+        "mkdir -p .cache",
         "pip install -r ./setup/requirements.txt torch==2.3.0 torchvision==0.18.0 torchaudio==2.3.0 --cache-dir /mount/.cache",
         "cd /mount/inference",
         "pip install -r ./requirements.txt --cache-dir /mount/.cache",

--- a/configs/phi-1_5/README.md
+++ b/configs/phi-1_5/README.md
@@ -102,7 +102,7 @@ Monitor the progress of the provision through the link displayed in the output c
 
 ### [Optional] Add Huggingface Token to the Azure Container App Secret
 If you're using private HuggingFace dataset, set your HuggingFace token as an environment variable to avoid the need for manual login on the Hugging Face Hub.
-You can do this using the `AI Toolkit: Add Azure Container Apps Job secret for fine-tuning command`. With this command, you can set the secret name as [`HUGGING_FACE_HUB_TOKEN`](https://huggingface.co/docs/huggingface_hub/package_reference/environment_variables#hftoken) and use your Hugging Face token as the secret value.
+You can do this using the `AI Toolkit: Add Azure Container Apps Job secret for fine-tuning command`. With this command, you can set the secret name as [`HF_TOKEN`](https://huggingface.co/docs/huggingface_hub/package_reference/environment_variables#hftoken) and use your Hugging Face token as the secret value.
 
 ### Run Fine-tuning
 To start the remote fine-tuning job, execute the `AI Toolkit: Run fine-tuning` command.

--- a/configs/phi-1_5/infra/provision/finetuning.parameters.json
+++ b/configs/phi-1_5/infra/provision/finetuning.parameters.json
@@ -5,8 +5,9 @@
     "defaultCommands": {
       "value": [
         "cd /mount",
-        "pip install -r ./setup/requirements.txt",
+        "pip install huggingface-hub==0.22.2",
         "huggingface-cli download microsoft/phi-1_5 --revision d38e6f954ec29b96fe2cf033937dad64e279b5d9 --local-dir ./model-cache/microsoft/phi-1_5 --local-dir-use-symlinks False --cache-dir ./cache/hfdownload",
+        "pip install -r ./setup/requirements.txt",
         "python3 ./finetuning/invoke_olive.py && find models/ -print | grep adapter/adapter"
       ]
     },

--- a/configs/phi-1_5/infra/provision/inference.bicep
+++ b/configs/phi-1_5/infra/provision/inference.bicep
@@ -192,8 +192,8 @@ resource acaApp 'Microsoft.App/containerApps@2023-11-02-preview' = {
                 scheme: 'HTTP'
               }
               initialDelaySeconds: 60
-              periodSeconds: 10
-              failureThreshold: 60
+              periodSeconds: 240
+              failureThreshold: 10
             }
           ]
           volumeMounts: [

--- a/configs/phi-1_5/infra/provision/inference.parameters.json
+++ b/configs/phi-1_5/infra/provision/inference.parameters.json
@@ -5,9 +5,10 @@
     "defaultCommands": {
       "value": [
         "cd /mount",
-        "pip install -r ./setup/requirements.txt",
+        "mkdir .cache",
+        "pip install -r ./setup/requirements.txt torch==2.3.0 torchvision==0.18.0 torchaudio==2.3.0 --cache-dir /mount/.cache",
         "cd /mount/inference",
-        "pip install -r ./requirements.txt",
+        "pip install -r ./requirements.txt --cache-dir /mount/.cache",
         "python3 ./gradio_chat.py"
       ]
     },

--- a/configs/phi-1_5/infra/provision/inference.parameters.json
+++ b/configs/phi-1_5/infra/provision/inference.parameters.json
@@ -5,7 +5,7 @@
     "defaultCommands": {
       "value": [
         "cd /mount",
-        "mkdir .cache",
+        "mkdir -p .cache",
         "pip install -r ./setup/requirements.txt torch==2.3.0 torchvision==0.18.0 torchaudio==2.3.0 --cache-dir /mount/.cache",
         "cd /mount/inference",
         "pip install -r ./requirements.txt --cache-dir /mount/.cache",

--- a/configs/phi-2/README.md
+++ b/configs/phi-2/README.md
@@ -102,7 +102,7 @@ Monitor the progress of the provision through the link displayed in the output c
 
 ### [Optional] Add Huggingface Token to the Azure Container App Secret
 If you're using private HuggingFace dataset, set your HuggingFace token as an environment variable to avoid the need for manual login on the Hugging Face Hub.
-You can do this using the `AI Toolkit: Add Azure Container Apps Job secret for fine-tuning command`. With this command, you can set the secret name as [`HUGGING_FACE_HUB_TOKEN`](https://huggingface.co/docs/huggingface_hub/package_reference/environment_variables#hftoken) and use your Hugging Face token as the secret value.
+You can do this using the `AI Toolkit: Add Azure Container Apps Job secret for fine-tuning command`. With this command, you can set the secret name as [`HF_TOKEN`](https://huggingface.co/docs/huggingface_hub/package_reference/environment_variables#hftoken) and use your Hugging Face token as the secret value.
 
 ### Run Fine-tuning
 To start the remote fine-tuning job, execute the `AI Toolkit: Run fine-tuning` command.

--- a/configs/phi-2/infra/provision/finetuning.parameters.json
+++ b/configs/phi-2/infra/provision/finetuning.parameters.json
@@ -5,8 +5,9 @@
     "defaultCommands": {
       "value": [
         "cd /mount",
-        "pip install -r ./setup/requirements.txt",
+        "pip install huggingface-hub==0.22.2",
         "huggingface-cli download microsoft/phi-2 --revision d3186761bf5c4409f7679359284066c25ab668ee --local-dir ./model-cache/microsoft/phi-2 --local-dir-use-symlinks False --cache-dir ./cache/hfdownload",
+        "pip install -r ./setup/requirements.txt",
         "python3 ./finetuning/invoke_olive.py && find models/ -print | grep adapter/adapter"
       ]
     },

--- a/configs/phi-2/infra/provision/inference.bicep
+++ b/configs/phi-2/infra/provision/inference.bicep
@@ -192,8 +192,8 @@ resource acaApp 'Microsoft.App/containerApps@2023-11-02-preview' = {
                 scheme: 'HTTP'
               }
               initialDelaySeconds: 60
-              periodSeconds: 10
-              failureThreshold: 60
+              periodSeconds: 240
+              failureThreshold: 10
             }
           ]
           volumeMounts: [

--- a/configs/phi-2/infra/provision/inference.parameters.json
+++ b/configs/phi-2/infra/provision/inference.parameters.json
@@ -5,9 +5,10 @@
     "defaultCommands": {
       "value": [
         "cd /mount",
-        "pip install -r ./setup/requirements.txt",
+        "mkdir .cache",
+        "pip install -r ./setup/requirements.txt torch==2.3.0 torchvision==0.18.0 torchaudio==2.3.0 --cache-dir /mount/.cache",
         "cd /mount/inference",
-        "pip install -r ./requirements.txt",
+        "pip install -r ./requirements.txt --cache-dir /mount/.cache",
         "python3 ./gradio_chat.py"
       ]
     },

--- a/configs/phi-2/infra/provision/inference.parameters.json
+++ b/configs/phi-2/infra/provision/inference.parameters.json
@@ -5,7 +5,7 @@
     "defaultCommands": {
       "value": [
         "cd /mount",
-        "mkdir .cache",
+        "mkdir -p .cache",
         "pip install -r ./setup/requirements.txt torch==2.3.0 torchvision==0.18.0 torchaudio==2.3.0 --cache-dir /mount/.cache",
         "cd /mount/inference",
         "pip install -r ./requirements.txt --cache-dir /mount/.cache",

--- a/configs/zephyr-7b-beta/README.md
+++ b/configs/zephyr-7b-beta/README.md
@@ -102,7 +102,7 @@ Monitor the progress of the provision through the link displayed in the output c
 
 ### [Optional] Add Huggingface Token to the Azure Container App Secret
 If you're using private HuggingFace dataset, set your HuggingFace token as an environment variable to avoid the need for manual login on the Hugging Face Hub.
-You can do this using the `AI Toolkit: Add Azure Container Apps Job secret for fine-tuning command`. With this command, you can set the secret name as [`HUGGING_FACE_HUB_TOKEN`](https://huggingface.co/docs/huggingface_hub/package_reference/environment_variables#hftoken) and use your Hugging Face token as the secret value.
+You can do this using the `AI Toolkit: Add Azure Container Apps Job secret for fine-tuning command`. With this command, you can set the secret name as [`HF_TOKEN`](https://huggingface.co/docs/huggingface_hub/package_reference/environment_variables#hftoken) and use your Hugging Face token as the secret value.
 
 ### Run Fine-tuning
 To start the remote fine-tuning job, execute the `AI Toolkit: Run fine-tuning` command.

--- a/configs/zephyr-7b-beta/infra/provision/finetuning.parameters.json
+++ b/configs/zephyr-7b-beta/infra/provision/finetuning.parameters.json
@@ -5,8 +5,9 @@
     "defaultCommands": {
       "value": [
         "cd /mount",
-        "pip install -r ./setup/requirements.txt",
+        "pip install huggingface-hub==0.22.2",
         "huggingface-cli download HuggingFaceH4/zephyr-7b-beta --revision main --local-dir ./model-cache/HuggingFaceH4/zephyr-7b-beta --local-dir-use-symlinks False --cache-dir ./cache/hfdownload",
+        "pip install -r ./setup/requirements.txt",
         "python3 ./finetuning/invoke_olive.py && find models/ -print | grep adapter/adapter"
       ]
     },

--- a/configs/zephyr-7b-beta/infra/provision/inference.bicep
+++ b/configs/zephyr-7b-beta/infra/provision/inference.bicep
@@ -192,8 +192,8 @@ resource acaApp 'Microsoft.App/containerApps@2023-11-02-preview' = {
                 scheme: 'HTTP'
               }
               initialDelaySeconds: 60
-              periodSeconds: 10
-              failureThreshold: 60
+              periodSeconds: 240
+              failureThreshold: 10
             }
           ]
           volumeMounts: [

--- a/configs/zephyr-7b-beta/infra/provision/inference.parameters.json
+++ b/configs/zephyr-7b-beta/infra/provision/inference.parameters.json
@@ -1,39 +1,40 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-      "defaultCommands": {
-        "value": [
-          "cd /mount",
-          "pip install -r ./setup/requirements.txt",
-          "cd /mount/inference",
-          "pip install -r ./requirements.txt",
-          "python3 ./gradio_chat.py"
-        ]
-      },
-      "maximumInstanceCount": {
-        "value": 2
-      },
-      "location": {
-        "value": null
-      },
-      "storageAccountName": {
-        "value": null
-      },
-      "fileShareName": {
-        "value": null
-      },
-      "acaEnvironmentName": {
-        "value": null
-      },
-      "acaEnvironmentStorageName": {
-        "value": null
-      },
-      "acaAppName": {
-        "value": null
-      },
-      "acaLogAnalyticsName": {
-        "value": null
-      }
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "defaultCommands": {
+      "value": [
+        "cd /mount",
+        "mkdir .cache",
+        "pip install -r ./setup/requirements.txt torch==2.3.0 torchvision==0.18.0 torchaudio==2.3.0 --cache-dir /mount/.cache",
+        "cd /mount/inference",
+        "pip install -r ./requirements.txt --cache-dir /mount/.cache",
+        "python3 ./gradio_chat.py"
+      ]
+    },
+    "maximumInstanceCount": {
+      "value": 2
+    },
+    "location": {
+      "value": null
+    },
+    "storageAccountName": {
+      "value": null
+    },
+    "fileShareName": {
+      "value": null
+    },
+    "acaEnvironmentName": {
+      "value": null
+    },
+    "acaEnvironmentStorageName": {
+      "value": null
+    },
+    "acaAppName": {
+      "value": null
+    },
+    "acaLogAnalyticsName": {
+      "value": null
     }
   }
+}

--- a/configs/zephyr-7b-beta/infra/provision/inference.parameters.json
+++ b/configs/zephyr-7b-beta/infra/provision/inference.parameters.json
@@ -5,7 +5,7 @@
     "defaultCommands": {
       "value": [
         "cd /mount",
-        "mkdir .cache",
+        "mkdir -p .cache",
         "pip install -r ./setup/requirements.txt torch==2.3.0 torchvision==0.18.0 torchaudio==2.3.0 --cache-dir /mount/.cache",
         "cd /mount/inference",
         "pip install -r ./requirements.txt --cache-dir /mount/.cache",


### PR DESCRIPTION
1. Use `huggingface-hub@0.22.2` to download model (Issue: https://github.com/huggingface/huggingface_hub/issues/2276)
2. Update hugging face token env name from `HUGGING_FACE_HUB_TOKEN` to `HF_TOKEN`, because `transformers` has been upgraded 
3. Move pip install cache to mount dir (Issue: https://github.com/microsoft/Skylight/issues/290)
4. Use pytorch 2.3.0 to avoid reinstall pytorch (Issue: https://github.com/microsoft/Skylight/issues/290)
5. Increase the inference aca startup timeout to be 40 mins (Issue: https://github.com/microsoft/Skylight/issues/290)