### PR TITLE
chore: improve mcp templates

### DIFF
--- a/mcpServers/python-weather/.vscode/tasks.json.tpl
+++ b/mcpServers/python-weather/.vscode/tasks.json.tpl
@@ -81,7 +81,7 @@
     {
       "id": "openAgentBuilder",
       "type": "command",
-      "command": "ai-mlstudio.promptBuilder",
+      "command": "ai-mlstudio.agentBuilder",
       "args": {
         "initialMCPs": [ "local-server-{{SafeProjectNameLowerCase}}" ],
         "triggeredFrom": "vsc-tasks"

--- a/mcpServers/typescript-weather/.vscode/launch.json
+++ b/mcpServers/typescript-weather/.vscode/launch.json
@@ -38,6 +38,29 @@
         "hidden": true
       },
       "internalConsoleOptions": "neverOpen"
+    },
+    {
+      "name": "Launch Inspector with STDIO settings",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": [
+        "run",
+        "dev:inspector",
+        "--",
+        "npm",
+        "--silent run dev:stdio"
+      ],
+      "skipFiles": ["<node_internals>/**"],
+      "console": "integratedTerminal",
+      "serverReadyAction": {
+        "action": "openExternally",
+        "pattern": "running at (https?://\\S+)",
+        "uriFormat": "%s?timeout=60000#tools"
+      },
+      "presentation": {
+        "hidden": true
+      },
     }
   ],
   "compounds": [
@@ -49,7 +72,7 @@
       "preLaunchTask": "Open Agent Builder",
     },
     {
-      "name": "Debug in Inspector (Edge)",
+      "name": "Debug SSE in Inspector (Edge)",
       "configurations": [
         "Launch Inspector (Edge)",
         "Attach to Local MCP"
@@ -58,12 +81,19 @@
       "stopAll": true
     },
     {
-      "name": "Debug in Inspector (Chrome)",
+      "name": "Debug SSE in Inspector (Chrome)",
       "configurations": [
         "Launch Inspector (Chrome)",
         "Attach to Local MCP"
       ],
       "preLaunchTask": "Start MCP Inspector",
+      "stopAll": true
+    },
+    {
+      "name": "Debug STDIO in Inspector",
+      "configurations": [
+        "Launch Inspector with STDIO settings"
+      ],
       "stopAll": true
     }
   ]

--- a/mcpServers/typescript-weather/.vscode/tasks.json.tpl
+++ b/mcpServers/typescript-weather/.vscode/tasks.json.tpl
@@ -83,7 +83,7 @@
     {
       "id": "openAgentBuilder",
       "type": "command",
-      "command": "ai-mlstudio.promptBuilder",
+      "command": "ai-mlstudio.agentBuilder",
       "args": {
         "initialMCPs": [ "local-server-{{SafeProjectNameLowerCase}}" ],
         "triggeredFrom": "vsc-tasks"

--- a/mcpServers/typescript-weather/README.md
+++ b/mcpServers/typescript-weather/README.md
@@ -30,9 +30,9 @@ First, before executing any code, install the dependencies.
 
 </details>
 
-### Debug in MCP Inspector
+### Debug SSE in MCP Inspector
 
-- Open VSCode Debug panel. Select `Debug in Inspector (Edge)` or `Debug in Inspector (Chrome)`. Press F5 to start debugging.
+- Open VSCode Debug panel. Select `Debug SSE in Inspector (Edge)` or `Debug SSE in Inspector (Chrome)`. Press F5 to start debugging.
 - When MCP Inspector launches in the browser, click the `Connect` button to connect this MCP server.
 - Then you can `List Tools`, select a tool, input parameters, and `Run Tool` to debug your server code.
 - Of course, you can add breakpoint to the tool implementation code.
@@ -46,5 +46,23 @@ First, before executing any code, install the dependencies.
   - then, the MCP Inspector is launched (by default on port 5173 and 3000)
 
   The whole definition can be found in [tasks.json](.vscode/tasks.json). You can also edit [launch.json](.vscode/launch.json), [tasks.json](.vscode/tasks.json), [index.ts](src/index.ts), [mcp.json](.aitk/mcp.json) to change above ports.
+
+</details>
+
+### Debug STDIO in MCP Inspector
+
+- Open VSCode Debug panel. Select `Debug STDIO in Inspector`. Press F5 to start debugging.
+- When MCP Inspector launches in your default browser, click the `Connect` button to connect this MCP server.
+- Then you can `List Tools`, select a tool, input parameters, and `Run Tool` to debug your server code.
+- Of course, you can add breakpoint to the tool implementation code.
+
+<details>
+  <summary>More Details</summary>
+
+  When launching debugging, it launches MCP Inspector with MCP settings pre-configured (default to `npm --silent run dev:stdio`).
+
+  After clicking `Connect`, Inspector launches MCP server on STDIO, which is also auto-attached for debugging via VSCode.
+
+  The whole definition can be found in [launch.json](.vscode/launch.json).
 
 </details>

--- a/mcpServers/typescript-weather/package.json.tpl
+++ b/mcpServers/typescript-weather/package.json.tpl
@@ -5,7 +5,7 @@
   "main": "./lib/src/index.js",
   "scripts": {
     "dev:sse": "nodemon --exec node --inspect=9239 --signal SIGINT -r ts-node/register ./src/index.ts sse",
-    "dev:stdio": "nodemon --exec node --inspect=9239 --signal SIGINT -r ts-node/register ./src/index.ts stdio",
+    "dev:stdio": "nodemon --quiet --exec node --signal SIGINT -r ts-node/register ./src/index.ts stdio",
     "dev:inspector": "mcp-inspector",
     "build": "tsc --build",
     "start:sse": "node ./lib/src/index.js sse",


### PR DESCRIPTION
- Use new "ai-mlstudio.agentBuilder" command.
- Support debugging stdio mcp with inspector (typescript) (ref: https://github.com/formulahendry/generator-mcp/blob/main/generators/app/templates/.vscode/launch.json)