### PR TITLE
Update cloud conversion bicep workload

### DIFF
--- a/model_lab_configs/biceps/cloudconversion.intelnpu.bicep
+++ b/model_lab_configs/biceps/cloudconversion.intelnpu.bicep
@@ -1,5 +1,4 @@
 param defaultCommands array
-param maximumInstanceCount int
 param timeout int
 param location string = resourceGroup().location
 
@@ -88,16 +87,8 @@ resource environment 'Microsoft.App/managedEnvironments@2023-11-02-preview' = {
         name: 'Consumption'
       }
       {
-        workloadProfileType: 'NC24-A100'
-        name: 'GPU'
-        minimumCount: 1
-        maximumCount: maximumInstanceCount
-      }
-      {
-        workloadProfileType: 'D16'
-        name: 'Dedicated-D16'
-        minimumCount: 1
-        maximumCount: maximumInstanceCount
+        workloadProfileType: 'Consumption-GPU-NC24-A100'
+        name: 'Consumption-GPU-NC24-A100'
       }
     ]
     appInsightsConfiguration: null
@@ -128,7 +119,7 @@ resource acajob 'Microsoft.App/jobs@2023-11-02-preview' = {
   location: location
   properties: {
     environmentId: environment.id
-    workloadProfileName: 'Dedicated-D16'
+    workloadProfileName: 'Consumption-GPU-NC24-A100'
     configuration: {
       secrets: null
       triggerType: 'Manual'
@@ -153,8 +144,8 @@ resource acajob 'Microsoft.App/jobs@2023-11-02-preview' = {
             defaultCommand
           ]
           resources: {
-            cpu: 16
-            memory: '64Gi'
+            cpu: 24
+            memory: '220Gi'
           }
           volumeMounts: [
             {

--- a/model_lab_configs/biceps/cloudconversion.nvidiagpu.bicep
+++ b/model_lab_configs/biceps/cloudconversion.nvidiagpu.bicep
@@ -1,5 +1,4 @@
 param defaultCommands array
-param maximumInstanceCount int
 param timeout int
 param location string = resourceGroup().location
 
@@ -88,16 +87,8 @@ resource environment 'Microsoft.App/managedEnvironments@2023-11-02-preview' = {
         name: 'Consumption'
       }
       {
-        workloadProfileType: 'NC24-A100'
-        name: 'GPU'
-        minimumCount: 1
-        maximumCount: maximumInstanceCount
-      }
-      {
-        workloadProfileType: 'D16'
-        name: 'Dedicated-D16'
-        minimumCount: 1
-        maximumCount: maximumInstanceCount
+        workloadProfileType: 'Consumption-GPU-NC24-A100'
+        name: 'Consumption-GPU-NC24-A100'
       }
     ]
     appInsightsConfiguration: null
@@ -128,7 +119,7 @@ resource acajob 'Microsoft.App/jobs@2023-11-02-preview' = {
   location: location
   properties: {
     environmentId: environment.id
-    workloadProfileName: 'GPU'
+    workloadProfileName: 'Consumption-GPU-NC24-A100'
     configuration: {
       secrets: null
       triggerType: 'Manual'

--- a/model_lab_configs/biceps/cloudconversion.parameters.json
+++ b/model_lab_configs/biceps/cloudconversion.parameters.json
@@ -6,9 +6,6 @@
       "value": [
       ]
     },
-    "maximumInstanceCount": {
-      "value": 2
-    },
     "timeout": {
       "value": 10800
     },

--- a/model_lab_configs/biceps/cloudconversion.wcr.bicep
+++ b/model_lab_configs/biceps/cloudconversion.wcr.bicep
@@ -88,14 +88,8 @@ resource environment 'Microsoft.App/managedEnvironments@2023-11-02-preview' = {
         name: 'Consumption'
       }
       {
-        workloadProfileType: 'NC24-A100'
-        name: 'GPU'
-        minimumCount: 1
-        maximumCount: maximumInstanceCount
-      }
-      {
-        workloadProfileType: 'D16'
-        name: 'Dedicated-D16'
+        workloadProfileType: 'Consumption-GPU-NC24-A100'
+        name: 'Consumption-GPU-NC24-A100'
         minimumCount: 1
         maximumCount: maximumInstanceCount
       }


### PR DESCRIPTION
Update cloud conversion bicep workload to Consumption-GPU-NC24-A100. This is a first choice for users in most cases.

For example, comparing with D16 we choose before, even we don't use GPU in Consumption-GPU-NC24-A100, it still be cheaper if user run less then 180 times a month.