### PR TITLE
Clarify AMD recipe naming: remove misleading term 'qnn'

### DIFF
--- a/model_lab_configs/huggingface/google-bert/bert-base-multilingual-cased/1/bert-base-multilingual-cased_qdq_amd.json
+++ b/model_lab_configs/huggingface/google-bert/bert-base-multilingual-cased/1/bert-base-multilingual-cased_qdq_amd.json
@@ -5,7 +5,7 @@
         "task": "feature-extraction"
     },
     "systems": {
-        "qnn_system": {
+        "local_system": {
             "type": "LocalSystem",
             "accelerators": [
                 {
@@ -159,8 +159,8 @@
             "quant_type": "OnnxStaticQuantization"
         }
     },
-    "host": "qnn_system",
-    "target": "qnn_system",
+    "host": "local_system",
+    "target": "local_system",
     "evaluator": "common_evaluator",
     "cache_dir": "cache",
     "output_dir": "model/google_bert",

--- a/model_lab_configs/huggingface/google-bert/bert-base-multilingual-cased/1/bert-base-multilingual-cased_qdq_amd.json.config
+++ b/model_lab_configs/huggingface/google-bert/bert-base-multilingual-cased/1/bert-base-multilingual-cased_qdq_amd.json.config
@@ -9,7 +9,7 @@
             "AMD NPU",
             "CPU"
         ],
-        "path": "systems.qnn_system.accelerators.0.execution_providers.0",
+        "path": "systems.local_system.accelerators.0.execution_providers.0",
         "values": [
             "VitisAIExecutionProvider",
             "CPUExecutionProvider"

--- a/model_lab_configs/huggingface/google/vit-base-patch16-224/1/vit-base-patch16-224_qdq_amd.json
+++ b/model_lab_configs/huggingface/google/vit-base-patch16-224/1/vit-base-patch16-224_qdq_amd.json
@@ -21,7 +21,7 @@
         }
     },
     "systems": {
-        "qnn_system": {
+        "local_system": {
             "type": "LocalSystem",
             "accelerators": [
                 {
@@ -148,8 +148,8 @@
             "quant_type": "OnnxStaticQuantization"
         }
     },
-    "host": "qnn_system",
-    "target": "qnn_system",
+    "host": "local_system",
+    "target": "local_system",
     "evaluator": "common_evaluator",
     "output_dir": "model/vit",
     "evaluate_input_model": false,

--- a/model_lab_configs/huggingface/google/vit-base-patch16-224/1/vit-base-patch16-224_qdq_amd.json.config
+++ b/model_lab_configs/huggingface/google/vit-base-patch16-224/1/vit-base-patch16-224_qdq_amd.json.config
@@ -9,7 +9,7 @@
             "AMD NPU",
             "CPU"
         ],
-        "path": "systems.qnn_system.accelerators.0.execution_providers.0",
+        "path": "systems.local_system.accelerators.0.execution_providers.0",
         "values": [
             "VitisAIExecutionProvider",
             "CPUExecutionProvider"

--- a/model_lab_configs/huggingface/microsoft/resnet-50/1/resnet_qdq_amd.json
+++ b/model_lab_configs/huggingface/microsoft/resnet-50/1/resnet_qdq_amd.json
@@ -21,7 +21,7 @@
         }
     },
     "systems": {
-        "qnn_system": {
+        "local_system": {
             "type": "LocalSystem",
             "accelerators": [
                 {
@@ -138,8 +138,8 @@
             "quant_type": "OnnxStaticQuantization"
         }
     },
-    "host": "qnn_system",
-    "target": "qnn_system",
+    "host": "local_system",
+    "target": "local_system",
     "evaluator": "common_evaluator",
     "cache_dir": "cache",
     "output_dir": "model/resnet_ptq_qnn",

--- a/model_lab_configs/huggingface/microsoft/resnet-50/1/resnet_qdq_amd.json.config
+++ b/model_lab_configs/huggingface/microsoft/resnet-50/1/resnet_qdq_amd.json.config
@@ -9,7 +9,7 @@
             "AMD NPU",
             "CPU"
         ],
-        "path": "systems.qnn_system.accelerators.0.execution_providers.0",
+        "path": "systems.local_system.accelerators.0.execution_providers.0",
         "values": [
             "VitisAIExecutionProvider",
             "CPUExecutionProvider"


### PR DESCRIPTION
Avoid using non-standard names like 'qnn' in AMD  recipe, as they can easily cause misunderstandings.