### PR TITLE
feat: add built-in recipes and hub catalog from WinML-CLI

### DIFF
--- a/model_lab_configs/winml_cli/BAAI_bge-large-en-v1.5/sentence-similarity/fp16_config.json
+++ b/model_lab_configs/winml_cli/BAAI_bge-large-en-v1.5/sentence-similarity/fp16_config.json
@@ -1,0 +1,77 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          30522
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "loader": {
+    "task": "sentence-similarity",
+    "model_class": "AutoModel",
+    "model_type": "bert"
+  },
+  "eval": {
+    "task": "sentence-similarity",
+    "dataset": {
+      "path": "mteb/stsbenchmark-sts",
+      "split": "test",
+      "columns_mapping": {
+        "input_column_1": "sentence1",
+        "input_column_2": "sentence2",
+        "score_column": "score"
+      }
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/BAAI_bge-large-en-v1.5/sentence-similarity/w8a16_config.json
+++ b/model_lab_configs/winml_cli/BAAI_bge-large-en-v1.5/sentence-similarity/w8a16_config.json
@@ -1,0 +1,94 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          30522
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": {
+    "mode": "qdq",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint16",
+    "per_channel": false,
+    "symmetric": false,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "sentence-similarity",
+    "model_name": "BAAI/bge-large-en-v1.5"
+  },
+  "loader": {
+    "task": "sentence-similarity",
+    "model_class": "AutoModel",
+    "model_type": "bert"
+  },
+  "eval": {
+    "task": "sentence-similarity",
+    "dataset": {
+      "path": "mteb/stsbenchmark-sts",
+      "split": "test",
+      "columns_mapping": {
+        "input_column_1": "sentence1",
+        "input_column_2": "sentence2",
+        "score_column": "score"
+      }
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/BAAI_bge-large-en-v1.5/sentence-similarity/w8a8_config.json
+++ b/model_lab_configs/winml_cli/BAAI_bge-large-en-v1.5/sentence-similarity/w8a8_config.json
@@ -1,0 +1,94 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          30522
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": {
+    "mode": "qdq",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "sentence-similarity",
+    "model_name": "BAAI/bge-large-en-v1.5"
+  },
+  "loader": {
+    "task": "sentence-similarity",
+    "model_class": "AutoModel",
+    "model_type": "bert"
+  },
+  "eval": {
+    "task": "sentence-similarity",
+    "dataset": {
+      "path": "mteb/stsbenchmark-sts",
+      "split": "test",
+      "columns_mapping": {
+        "input_column_1": "sentence1",
+        "input_column_2": "sentence2",
+        "score_column": "score"
+      }
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/cardiffnlp_twitter-roberta-base-sentiment-latest/text-classification/fp16_config.json
+++ b/model_lab_configs/winml_cli/cardiffnlp_twitter-roberta-base-sentiment-latest/text-classification/fp16_config.json
@@ -1,0 +1,63 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          50265
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "loader": {
+    "task": "text-classification",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "roberta"
+  },
+  "eval": {
+    "task": "text-classification",
+    "dataset": {
+      "path": "tweet_eval",
+      "name": "sentiment",
+      "columns_mapping": {
+        "input_column": "text"
+      }
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/cardiffnlp_twitter-roberta-base-sentiment-latest/text-classification/w8a16_config.json
+++ b/model_lab_configs/winml_cli/cardiffnlp_twitter-roberta-base-sentiment-latest/text-classification/w8a16_config.json
@@ -1,0 +1,80 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          50265
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": {
+    "mode": "qdq",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint16",
+    "per_channel": false,
+    "symmetric": false,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "text-classification",
+    "model_name": "cardiffnlp/twitter-roberta-base-sentiment-latest"
+  },
+  "loader": {
+    "task": "text-classification",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "roberta"
+  },
+  "eval": {
+    "task": "text-classification",
+    "dataset": {
+      "path": "tweet_eval",
+      "name": "sentiment",
+      "columns_mapping": {
+        "input_column": "text"
+      }
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/cardiffnlp_twitter-roberta-base-sentiment-latest/text-classification/w8a8_config.json
+++ b/model_lab_configs/winml_cli/cardiffnlp_twitter-roberta-base-sentiment-latest/text-classification/w8a8_config.json
@@ -1,0 +1,80 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          50265
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": {
+    "mode": "qdq",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "text-classification",
+    "model_name": "cardiffnlp/twitter-roberta-base-sentiment-latest"
+  },
+  "loader": {
+    "task": "text-classification",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "roberta"
+  },
+  "eval": {
+    "task": "text-classification",
+    "dataset": {
+      "path": "tweet_eval",
+      "name": "sentiment",
+      "columns_mapping": {
+        "input_column": "text"
+      }
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/deepset_roberta-base-squad2/question-answering/fp16_config.json
+++ b/model_lab_configs/winml_cli/deepset_roberta-base-squad2/question-answering/fp16_config.json
@@ -1,0 +1,69 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          50265
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "start_logits"
+      },
+      {
+        "name": "end_logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "loader": {
+    "task": "question-answering",
+    "model_class": "AutoModelForQuestionAnswering",
+    "model_type": "roberta"
+  },
+  "eval": {
+    "task": "question-answering",
+    "dataset": {
+      "path": "rajpurkar/squad_v2",
+      "split": "validation",
+      "columns_mapping": {
+        "question_column": "question",
+        "context_column": "context",
+        "id_column": "id",
+        "label_column": "answers"
+      }
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/deepset_roberta-base-squad2/question-answering/w8a16_config.json
+++ b/model_lab_configs/winml_cli/deepset_roberta-base-squad2/question-answering/w8a16_config.json
@@ -1,0 +1,86 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          50265
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "start_logits"
+      },
+      {
+        "name": "end_logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": {
+    "mode": "qdq",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint16",
+    "per_channel": false,
+    "symmetric": false,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "question-answering",
+    "model_name": "deepset/roberta-base-squad2"
+  },
+  "loader": {
+    "task": "question-answering",
+    "model_class": "AutoModelForQuestionAnswering",
+    "model_type": "roberta"
+  },
+  "eval": {
+    "task": "question-answering",
+    "dataset": {
+      "path": "rajpurkar/squad_v2",
+      "split": "validation",
+      "columns_mapping": {
+        "question_column": "question",
+        "context_column": "context",
+        "id_column": "id",
+        "label_column": "answers"
+      }
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/deepset_roberta-base-squad2/question-answering/w8a8_config.json
+++ b/model_lab_configs/winml_cli/deepset_roberta-base-squad2/question-answering/w8a8_config.json
@@ -1,0 +1,86 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          50265
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "start_logits"
+      },
+      {
+        "name": "end_logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": {
+    "mode": "qdq",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "question-answering",
+    "model_name": "deepset/roberta-base-squad2"
+  },
+  "loader": {
+    "task": "question-answering",
+    "model_class": "AutoModelForQuestionAnswering",
+    "model_type": "roberta"
+  },
+  "eval": {
+    "task": "question-answering",
+    "dataset": {
+      "path": "rajpurkar/squad_v2",
+      "split": "validation",
+      "columns_mapping": {
+        "question_column": "question",
+        "context_column": "context",
+        "id_column": "id",
+        "label_column": "answers"
+      }
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/deepset_tinyroberta-squad2/question-answering/fp16_config.json
+++ b/model_lab_configs/winml_cli/deepset_tinyroberta-squad2/question-answering/fp16_config.json
@@ -1,0 +1,69 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          50265
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "start_logits"
+      },
+      {
+        "name": "end_logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "loader": {
+    "task": "question-answering",
+    "model_class": "AutoModelForQuestionAnswering",
+    "model_type": "roberta"
+  },
+  "eval": {
+    "task": "question-answering",
+    "dataset": {
+      "path": "rajpurkar/squad_v2",
+      "split": "validation",
+      "columns_mapping": {
+        "question_column": "question",
+        "context_column": "context",
+        "id_column": "id",
+        "label_column": "answers"
+      }
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/deepset_tinyroberta-squad2/question-answering/w8a16_config.json
+++ b/model_lab_configs/winml_cli/deepset_tinyroberta-squad2/question-answering/w8a16_config.json
@@ -1,0 +1,86 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          50265
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "start_logits"
+      },
+      {
+        "name": "end_logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": {
+    "mode": "qdq",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint16",
+    "per_channel": false,
+    "symmetric": false,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "question-answering",
+    "model_name": "deepset/tinyroberta-squad2"
+  },
+  "loader": {
+    "task": "question-answering",
+    "model_class": "AutoModelForQuestionAnswering",
+    "model_type": "roberta"
+  },
+  "eval": {
+    "task": "question-answering",
+    "dataset": {
+      "path": "rajpurkar/squad_v2",
+      "split": "validation",
+      "columns_mapping": {
+        "question_column": "question",
+        "context_column": "context",
+        "id_column": "id",
+        "label_column": "answers"
+      }
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/deepset_tinyroberta-squad2/question-answering/w8a8_config.json
+++ b/model_lab_configs/winml_cli/deepset_tinyroberta-squad2/question-answering/w8a8_config.json
@@ -1,0 +1,86 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          50265
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "start_logits"
+      },
+      {
+        "name": "end_logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": {
+    "mode": "qdq",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "question-answering",
+    "model_name": "deepset/tinyroberta-squad2"
+  },
+  "loader": {
+    "task": "question-answering",
+    "model_class": "AutoModelForQuestionAnswering",
+    "model_type": "roberta"
+  },
+  "eval": {
+    "task": "question-answering",
+    "dataset": {
+      "path": "rajpurkar/squad_v2",
+      "split": "validation",
+      "columns_mapping": {
+        "question_column": "question",
+        "context_column": "context",
+        "id_column": "id",
+        "label_column": "answers"
+      }
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/facebook_dinov2-base/image-feature-extraction/fp16_config.json
+++ b/model_lab_configs/winml_cli/facebook_dinov2-base/image-feature-extraction/fp16_config.json
@@ -1,0 +1,49 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          224,
+          224
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "loader": {
+    "task": "image-feature-extraction",
+    "model_class": "AutoModel",
+    "model_type": "dinov2"
+  },
+  "eval": {
+    "task": "image-feature-extraction",
+    "dataset": {
+      "path": "timm/mini-imagenet",
+      "split": "test",
+      "samples": 1000
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/facebook_dinov2-base/image-feature-extraction/w8a16_config.json
+++ b/model_lab_configs/winml_cli/facebook_dinov2-base/image-feature-extraction/w8a16_config.json
@@ -1,0 +1,66 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          224,
+          224
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "qdq",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint16",
+    "per_channel": false,
+    "symmetric": false,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "image-feature-extraction",
+    "model_name": "facebook/dinov2-base"
+  },
+  "loader": {
+    "task": "image-feature-extraction",
+    "model_class": "AutoModel",
+    "model_type": "dinov2"
+  },
+  "eval": {
+    "task": "image-feature-extraction",
+    "dataset": {
+      "path": "timm/mini-imagenet",
+      "split": "test",
+      "samples": 1000
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/facebook_dinov2-base/image-feature-extraction/w8a8_config.json
+++ b/model_lab_configs/winml_cli/facebook_dinov2-base/image-feature-extraction/w8a8_config.json
@@ -1,0 +1,66 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          224,
+          224
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "qdq",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "image-feature-extraction",
+    "model_name": "facebook/dinov2-base"
+  },
+  "loader": {
+    "task": "image-feature-extraction",
+    "model_class": "AutoModel",
+    "model_type": "dinov2"
+  },
+  "eval": {
+    "task": "image-feature-extraction",
+    "dataset": {
+      "path": "timm/mini-imagenet",
+      "split": "test",
+      "samples": 1000
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/facebook_dinov2-small/image-feature-extraction/fp16_config.json
+++ b/model_lab_configs/winml_cli/facebook_dinov2-small/image-feature-extraction/fp16_config.json
@@ -1,0 +1,49 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          224,
+          224
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "loader": {
+    "task": "image-feature-extraction",
+    "model_class": "AutoModel",
+    "model_type": "dinov2"
+  },
+  "eval": {
+    "task": "image-feature-extraction",
+    "dataset": {
+      "path": "timm/mini-imagenet",
+      "split": "test",
+      "samples": 1000
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/facebook_dinov2-small/image-feature-extraction/w8a16_config.json
+++ b/model_lab_configs/winml_cli/facebook_dinov2-small/image-feature-extraction/w8a16_config.json
@@ -1,0 +1,66 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          224,
+          224
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "qdq",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint16",
+    "per_channel": false,
+    "symmetric": false,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "image-feature-extraction",
+    "model_name": "facebook/dinov2-small"
+  },
+  "loader": {
+    "task": "image-feature-extraction",
+    "model_class": "AutoModel",
+    "model_type": "dinov2"
+  },
+  "eval": {
+    "task": "image-feature-extraction",
+    "dataset": {
+      "path": "timm/mini-imagenet",
+      "split": "test",
+      "samples": 1000
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/facebook_dinov2-small/image-feature-extraction/w8a8_config.json
+++ b/model_lab_configs/winml_cli/facebook_dinov2-small/image-feature-extraction/w8a8_config.json
@@ -1,0 +1,66 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          224,
+          224
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "qdq",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "image-feature-extraction",
+    "model_name": "facebook/dinov2-small"
+  },
+  "loader": {
+    "task": "image-feature-extraction",
+    "model_class": "AutoModel",
+    "model_type": "dinov2"
+  },
+  "eval": {
+    "task": "image-feature-extraction",
+    "dataset": {
+      "path": "timm/mini-imagenet",
+      "split": "test",
+      "samples": 1000
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/google_vit-base-patch16-224-in21k/image-feature-extraction/fp16_config.json
+++ b/model_lab_configs/winml_cli/google_vit-base-patch16-224-in21k/image-feature-extraction/fp16_config.json
@@ -1,0 +1,49 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          224,
+          224
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "loader": {
+    "task": "image-feature-extraction",
+    "model_class": "AutoModel",
+    "model_type": "vit"
+  },
+  "eval": {
+    "task": "image-feature-extraction",
+    "dataset": {
+      "path": "timm/mini-imagenet",
+      "split": "test",
+      "samples": 1000
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/google_vit-base-patch16-224-in21k/image-feature-extraction/w8a16_config.json
+++ b/model_lab_configs/winml_cli/google_vit-base-patch16-224-in21k/image-feature-extraction/w8a16_config.json
@@ -1,0 +1,66 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          224,
+          224
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "qdq",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint16",
+    "per_channel": false,
+    "symmetric": false,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "image-feature-extraction",
+    "model_name": "google/vit-base-patch16-224-in21k"
+  },
+  "loader": {
+    "task": "image-feature-extraction",
+    "model_class": "AutoModel",
+    "model_type": "vit"
+  },
+  "eval": {
+    "task": "image-feature-extraction",
+    "dataset": {
+      "path": "timm/mini-imagenet",
+      "split": "test",
+      "samples": 1000
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/google_vit-base-patch16-224-in21k/image-feature-extraction/w8a8_config.json
+++ b/model_lab_configs/winml_cli/google_vit-base-patch16-224-in21k/image-feature-extraction/w8a8_config.json
@@ -1,0 +1,66 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          224,
+          224
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "qdq",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "image-feature-extraction",
+    "model_name": "google/vit-base-patch16-224-in21k"
+  },
+  "loader": {
+    "task": "image-feature-extraction",
+    "model_class": "AutoModel",
+    "model_type": "vit"
+  },
+  "eval": {
+    "task": "image-feature-extraction",
+    "dataset": {
+      "path": "timm/mini-imagenet",
+      "split": "test",
+      "samples": 1000
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/laion_CLIP-ViT-B-32-laion2B-s34B-b79K/feature-extraction/fp16_config.json
+++ b/model_lab_configs/winml_cli/laion_CLIP-ViT-B-32-laion2B-s34B-b79K/feature-extraction/fp16_config.json
@@ -1,0 +1,71 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          77
+        ],
+        "value_range": [
+          0,
+          49408
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          77
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "text_embeds"
+      },
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true,
+    "gelu_fusion": true,
+    "layer_norm_fusion": true,
+    "matmul_add_fusion": true
+  },
+  "quant": null,
+  "loader": {
+    "task": "feature-extraction",
+    "model_class": "CLIPTextModelWithProjection",
+    "model_type": "clip_text_model"
+  },
+  "eval": {
+    "task": "feature-extraction",
+    "dataset": {
+      "path": "mteb/stsbenchmark-sts",
+      "split": "test",
+      "columns_mapping": {
+        "input_column_1": "sentence1",
+        "input_column_2": "sentence2",
+        "score_column": "score"
+      }
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/laion_CLIP-ViT-B-32-laion2B-s34B-b79K/feature-extraction/w8a16_config.json
+++ b/model_lab_configs/winml_cli/laion_CLIP-ViT-B-32-laion2B-s34B-b79K/feature-extraction/w8a16_config.json
@@ -1,0 +1,88 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          77
+        ],
+        "value_range": [
+          0,
+          49408
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          77
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "text_embeds"
+      },
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true,
+    "gelu_fusion": true,
+    "layer_norm_fusion": true,
+    "matmul_add_fusion": true
+  },
+  "quant": {
+    "mode": "qdq",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint16",
+    "per_channel": false,
+    "symmetric": false,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "feature-extraction",
+    "model_name": "laion/CLIP-ViT-B-32-laion2B-s34B-b79K"
+  },
+  "loader": {
+    "task": "feature-extraction",
+    "model_class": "CLIPTextModelWithProjection",
+    "model_type": "clip_text_model"
+  },
+  "eval": {
+    "task": "feature-extraction",
+    "dataset": {
+      "path": "mteb/stsbenchmark-sts",
+      "split": "test",
+      "columns_mapping": {
+        "input_column_1": "sentence1",
+        "input_column_2": "sentence2",
+        "score_column": "score"
+      }
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/laion_CLIP-ViT-B-32-laion2B-s34B-b79K/feature-extraction/w8a8_config.json
+++ b/model_lab_configs/winml_cli/laion_CLIP-ViT-B-32-laion2B-s34B-b79K/feature-extraction/w8a8_config.json
@@ -1,0 +1,88 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          77
+        ],
+        "value_range": [
+          0,
+          49408
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          77
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "text_embeds"
+      },
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true,
+    "gelu_fusion": true,
+    "layer_norm_fusion": true,
+    "matmul_add_fusion": true
+  },
+  "quant": {
+    "mode": "qdq",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "feature-extraction",
+    "model_name": "laion/CLIP-ViT-B-32-laion2B-s34B-b79K"
+  },
+  "loader": {
+    "task": "feature-extraction",
+    "model_class": "CLIPTextModelWithProjection",
+    "model_type": "clip_text_model"
+  },
+  "eval": {
+    "task": "feature-extraction",
+    "dataset": {
+      "path": "mteb/stsbenchmark-sts",
+      "split": "test",
+      "columns_mapping": {
+        "input_column_1": "sentence1",
+        "input_column_2": "sentence2",
+        "score_column": "score"
+      }
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/microsoft_rad-dino/image-feature-extraction/fp16_config.json
+++ b/model_lab_configs/winml_cli/microsoft_rad-dino/image-feature-extraction/fp16_config.json
@@ -1,0 +1,49 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          518,
+          518
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "loader": {
+    "task": "image-feature-extraction",
+    "model_class": "AutoModel",
+    "model_type": "dinov2"
+  },
+  "eval": {
+    "task": "image-feature-extraction",
+    "dataset": {
+      "path": "Ewakaa/pneumonia_classification_chest_xray",
+      "split": "test",
+      "samples": 582
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/microsoft_rad-dino/image-feature-extraction/w8a16_config.json
+++ b/model_lab_configs/winml_cli/microsoft_rad-dino/image-feature-extraction/w8a16_config.json
@@ -1,0 +1,66 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          518,
+          518
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "qdq",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint16",
+    "per_channel": false,
+    "symmetric": false,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "image-feature-extraction",
+    "model_name": "microsoft/rad-dino"
+  },
+  "loader": {
+    "task": "image-feature-extraction",
+    "model_class": "AutoModel",
+    "model_type": "dinov2"
+  },
+  "eval": {
+    "task": "image-feature-extraction",
+    "dataset": {
+      "path": "Ewakaa/pneumonia_classification_chest_xray",
+      "split": "test",
+      "samples": 582
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/microsoft_rad-dino/image-feature-extraction/w8a8_config.json
+++ b/model_lab_configs/winml_cli/microsoft_rad-dino/image-feature-extraction/w8a8_config.json
@@ -1,0 +1,66 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          518,
+          518
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "qdq",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "image-feature-extraction",
+    "model_name": "microsoft/rad-dino"
+  },
+  "loader": {
+    "task": "image-feature-extraction",
+    "model_class": "AutoModel",
+    "model_type": "dinov2"
+  },
+  "eval": {
+    "task": "image-feature-extraction",
+    "dataset": {
+      "path": "Ewakaa/pneumonia_classification_chest_xray",
+      "split": "test",
+      "samples": 582
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/openai_clip-vit-base-patch16/feature-extraction/fp16_config.json
+++ b/model_lab_configs/winml_cli/openai_clip-vit-base-patch16/feature-extraction/fp16_config.json
@@ -1,0 +1,71 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          77
+        ],
+        "value_range": [
+          0,
+          49408
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          77
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "text_embeds"
+      },
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true,
+    "gelu_fusion": true,
+    "layer_norm_fusion": true,
+    "matmul_add_fusion": true
+  },
+  "quant": null,
+  "loader": {
+    "task": "feature-extraction",
+    "model_class": "CLIPTextModelWithProjection",
+    "model_type": "clip_text_model"
+  },
+  "eval": {
+    "task": "feature-extraction",
+    "dataset": {
+      "path": "mteb/stsbenchmark-sts",
+      "split": "test",
+      "columns_mapping": {
+        "input_column_1": "sentence1",
+        "input_column_2": "sentence2",
+        "score_column": "score"
+      }
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/openai_clip-vit-base-patch16/feature-extraction/w8a16_config.json
+++ b/model_lab_configs/winml_cli/openai_clip-vit-base-patch16/feature-extraction/w8a16_config.json
@@ -1,0 +1,88 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          77
+        ],
+        "value_range": [
+          0,
+          49408
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          77
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "text_embeds"
+      },
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true,
+    "gelu_fusion": true,
+    "layer_norm_fusion": true,
+    "matmul_add_fusion": true
+  },
+  "quant": {
+    "mode": "qdq",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint16",
+    "per_channel": false,
+    "symmetric": false,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "feature-extraction",
+    "model_name": "openai/clip-vit-base-patch16"
+  },
+  "loader": {
+    "task": "feature-extraction",
+    "model_class": "CLIPTextModelWithProjection",
+    "model_type": "clip_text_model"
+  },
+  "eval": {
+    "task": "feature-extraction",
+    "dataset": {
+      "path": "mteb/stsbenchmark-sts",
+      "split": "test",
+      "columns_mapping": {
+        "input_column_1": "sentence1",
+        "input_column_2": "sentence2",
+        "score_column": "score"
+      }
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/openai_clip-vit-base-patch16/feature-extraction/w8a8_config.json
+++ b/model_lab_configs/winml_cli/openai_clip-vit-base-patch16/feature-extraction/w8a8_config.json
@@ -1,0 +1,88 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          77
+        ],
+        "value_range": [
+          0,
+          49408
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          77
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "text_embeds"
+      },
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true,
+    "gelu_fusion": true,
+    "layer_norm_fusion": true,
+    "matmul_add_fusion": true
+  },
+  "quant": {
+    "mode": "qdq",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "feature-extraction",
+    "model_name": "openai/clip-vit-base-patch16"
+  },
+  "loader": {
+    "task": "feature-extraction",
+    "model_class": "CLIPTextModelWithProjection",
+    "model_type": "clip_text_model"
+  },
+  "eval": {
+    "task": "feature-extraction",
+    "dataset": {
+      "path": "mteb/stsbenchmark-sts",
+      "split": "test",
+      "columns_mapping": {
+        "input_column_1": "sentence1",
+        "input_column_2": "sentence2",
+        "score_column": "score"
+      }
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/sentence-transformers_all-MiniLM-L6-v2/feature-extraction/fp16_config.json
+++ b/model_lab_configs/winml_cli/sentence-transformers_all-MiniLM-L6-v2/feature-extraction/fp16_config.json
@@ -1,0 +1,77 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          30522
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "loader": {
+    "task": "feature-extraction",
+    "model_class": "AutoModel",
+    "model_type": "bert"
+  },
+  "eval": {
+    "task": "feature-extraction",
+    "dataset": {
+      "path": "mteb/stsbenchmark-sts",
+      "split": "test",
+      "columns_mapping": {
+        "input_column_1": "sentence1",
+        "input_column_2": "sentence2",
+        "score_column": "score"
+      }
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/sentence-transformers_all-MiniLM-L6-v2/feature-extraction/w8a16_config.json
+++ b/model_lab_configs/winml_cli/sentence-transformers_all-MiniLM-L6-v2/feature-extraction/w8a16_config.json
@@ -1,0 +1,94 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          30522
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": {
+    "mode": "qdq",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint16",
+    "per_channel": false,
+    "symmetric": false,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "feature-extraction",
+    "model_name": "sentence-transformers/all-MiniLM-L6-v2"
+  },
+  "loader": {
+    "task": "feature-extraction",
+    "model_class": "AutoModel",
+    "model_type": "bert"
+  },
+  "eval": {
+    "task": "feature-extraction",
+    "dataset": {
+      "path": "mteb/stsbenchmark-sts",
+      "split": "test",
+      "columns_mapping": {
+        "input_column_1": "sentence1",
+        "input_column_2": "sentence2",
+        "score_column": "score"
+      }
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/sentence-transformers_all-MiniLM-L6-v2/feature-extraction/w8a8_config.json
+++ b/model_lab_configs/winml_cli/sentence-transformers_all-MiniLM-L6-v2/feature-extraction/w8a8_config.json
@@ -1,0 +1,94 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          30522
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": {
+    "mode": "qdq",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "feature-extraction",
+    "model_name": "sentence-transformers/all-MiniLM-L6-v2"
+  },
+  "loader": {
+    "task": "feature-extraction",
+    "model_class": "AutoModel",
+    "model_type": "bert"
+  },
+  "eval": {
+    "task": "feature-extraction",
+    "dataset": {
+      "path": "mteb/stsbenchmark-sts",
+      "split": "test",
+      "columns_mapping": {
+        "input_column_1": "sentence1",
+        "input_column_2": "sentence2",
+        "score_column": "score"
+      }
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/sentence-transformers_all-MiniLM-L6-v2/sentence-similarity/fp16_config.json
+++ b/model_lab_configs/winml_cli/sentence-transformers_all-MiniLM-L6-v2/sentence-similarity/fp16_config.json
@@ -1,0 +1,77 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          30522
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "loader": {
+    "task": "sentence-similarity",
+    "model_class": "AutoModel",
+    "model_type": "bert"
+  },
+  "eval": {
+    "task": "sentence-similarity",
+    "dataset": {
+      "path": "mteb/stsbenchmark-sts",
+      "split": "test",
+      "columns_mapping": {
+        "input_column_1": "sentence1",
+        "input_column_2": "sentence2",
+        "score_column": "score"
+      }
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/sentence-transformers_all-MiniLM-L6-v2/sentence-similarity/w8a16_config.json
+++ b/model_lab_configs/winml_cli/sentence-transformers_all-MiniLM-L6-v2/sentence-similarity/w8a16_config.json
@@ -1,0 +1,94 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          30522
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": {
+    "mode": "qdq",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint16",
+    "per_channel": false,
+    "symmetric": false,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "sentence-similarity",
+    "model_name": "sentence-transformers/all-MiniLM-L6-v2"
+  },
+  "loader": {
+    "task": "sentence-similarity",
+    "model_class": "AutoModel",
+    "model_type": "bert"
+  },
+  "eval": {
+    "task": "sentence-similarity",
+    "dataset": {
+      "path": "mteb/stsbenchmark-sts",
+      "split": "test",
+      "columns_mapping": {
+        "input_column_1": "sentence1",
+        "input_column_2": "sentence2",
+        "score_column": "score"
+      }
+    }
+  }
+}

--- a/model_lab_configs/winml_cli/sentence-transformers_all-MiniLM-L6-v2/sentence-similarity/w8a8_config.json
+++ b/model_lab_configs/winml_cli/sentence-transformers_all-MiniLM-L6-v2/sentence-similarity/w8a8_config.json
@@ -1,0 +1,94 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          30522
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": {
+    "mode": "qdq",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "sentence-similarity",
+    "model_name": "sentence-transformers/all-MiniLM-L6-v2"
+  },
+  "loader": {
+    "task": "sentence-similarity",
+    "model_class": "AutoModel",
+    "model_type": "bert"
+  },
+  "eval": {
+    "task": "sentence-similarity",
+    "dataset": {
+      "path": "mteb/stsbenchmark-sts",
+      "split": "test",
+      "columns_mapping": {
+        "input_column_1": "sentence1",
+        "input_column_2": "sentence2",
+        "score_column": "score"
+      }
+    }
+  }
+}

--- a/model_lab_configs/winml_cli_catalog.json
+++ b/model_lab_configs/winml_cli_catalog.json
@@ -1,0 +1,74 @@
+[
+  {
+    "model_id": "BAAI/bge-large-en-v1.5",
+    "description": "High-capacity English text embedding model (335M params) for semantic similarity.",
+    "model_type": "bert",
+    "task": "sentence-similarity"
+  },
+  {
+    "model_id": "cardiffnlp/twitter-roberta-base-sentiment-latest",
+    "description": "RoBERTa model fine-tuned on ~124M tweets for sentiment analysis (positive/negative/neutral).",
+    "model_type": "roberta",
+    "task": "text-classification"
+  },
+  {
+    "model_id": "deepset/roberta-base-squad2",
+    "description": "RoBERTa-base fine-tuned on SQuAD 2.0 for extractive question answering.",
+    "model_type": "roberta",
+    "task": "question-answering"
+  },
+  {
+    "model_id": "deepset/tinyroberta-squad2",
+    "description": "Compact RoBERTa model fine-tuned on SQuAD 2.0 for lightweight question answering.",
+    "model_type": "roberta",
+    "task": "question-answering"
+  },
+  {
+    "model_id": "facebook/dinov2-base",
+    "description": "DINOv2 base self-supervised vision model for general-purpose image feature extraction.",
+    "model_type": "dinov2",
+    "task": "image-feature-extraction"
+  },
+  {
+    "model_id": "facebook/dinov2-small",
+    "description": "DINOv2 small self-supervised vision model for efficient image feature extraction.",
+    "model_type": "dinov2",
+    "task": "image-feature-extraction"
+  },
+  {
+    "model_id": "google/vit-base-patch16-224-in21k",
+    "description": "Vision Transformer base pretrained on ImageNet-21k for image feature extraction.",
+    "model_type": "vit",
+    "task": "image-feature-extraction"
+  },
+  {
+    "model_id": "laion/CLIP-ViT-B-32-laion2B-s34B-b79K",
+    "description": "LAION CLIP ViT-B/32 trained on 2B image-text pairs for joint image/text feature extraction.",
+    "model_type": "clip",
+    "task": "feature-extraction"
+  },
+  {
+    "model_id": "microsoft/rad-dino",
+    "description": "DINOv2-based vision model fine-tuned on chest X-rays for radiology feature extraction.",
+    "model_type": "dinov2",
+    "task": "image-feature-extraction"
+  },
+  {
+    "model_id": "openai/clip-vit-base-patch16",
+    "description": "CLIP ViT-B/16 model for joint image-text embeddings with 16x16 patch size.",
+    "model_type": "clip",
+    "task": "feature-extraction"
+  },
+  {
+    "model_id": "sentence-transformers/all-MiniLM-L6-v2",
+    "description": "Lightweight sentence embedding model mapping text to 384-dim dense vectors.",
+    "model_type": "bert",
+    "task": "feature-extraction"
+  },
+  {
+    "model_id": "sentence-transformers/all-MiniLM-L6-v2",
+    "description": "Lightweight sentence embedding model optimized for semantic similarity tasks.",
+    "model_type": "bert",
+    "task": "sentence-similarity"
+  }
+]


### PR DESCRIPTION
Adds 11 model folders (BAAI, cardiffnlp, deepset, facebook, google, laion, microsoft, openai, sentence-transformers) with fp16/w8a8/w8a16 configs per task, plus wmk_hub_catalog.json manifest.