### PR TITLE
Update LoRA/soft-prompt finetuning images to mcr.microsoft.com/foundrytoolkit

### DIFF
--- a/finetuning_configs/microsoft/phi-silica-3.6/1/lora/infra/provision/finetuning.bicep
+++ b/finetuning_configs/microsoft/phi-silica-3.6/1/lora/infra/provision/finetuning.bicep
@@ -129,7 +129,7 @@ resource acajob 'Microsoft.App/jobs@2023-11-02-preview' = {
     template: {
       containers: [
         {
-          image: 'crsdcbuild2025.azurecr.io/phi-silica-fine-tune-containers-lora:latest'
+          image: 'mcr.microsoft.com/foundrytoolkit/lora:20260630.1'
           name: acaJobName
           resources: {
             cpu: 24

--- a/finetuning_configs/microsoft/phi-silica-3.6/1/soft_prompt/infra/provision/finetuning.bicep
+++ b/finetuning_configs/microsoft/phi-silica-3.6/1/soft_prompt/infra/provision/finetuning.bicep
@@ -129,7 +129,7 @@ resource acajob 'Microsoft.App/jobs@2023-11-02-preview' = {
     template: {
       containers: [
         {
-          image: 'crsdcbuild2025.azurecr.io/artifact/e9623811-ed23-4d6c-8c56-a27494f2c808/buddy/phi-silica-fine-tune-containers-soft-prompt:20250730.1'
+          image: 'mcr.microsoft.com/foundrytoolkit/soft-prompt:20260630.1'
           name: acaJobName
           resources: {
             cpu: 24


### PR DESCRIPTION
Points the phi-silica-3.6 LoRA and soft-prompt ACA finetuning jobs at the published Foundry Toolkit images on MCR (replacing the `crsdcbuild2025` dev ACR).

- `lora` -> `mcr.microsoft.com/foundrytoolkit/lora:20260630.1`
- `soft-prompt` -> `mcr.microsoft.com/foundrytoolkit/soft-prompt:20260630.1`

Files:
- `finetuning_configs/microsoft/phi-silica-3.6/1/lora/infra/provision/finetuning.bicep`
- `finetuning_configs/microsoft/phi-silica-3.6/1/soft_prompt/infra/provision/finetuning.bicep`

MCR publish status: https://status-portal.mscr.io/?ownershipFilter=0&repoFilter=unlisted%2Ffoundrytoolkit